### PR TITLE
Use the timing of the active strip when creating New Shots

### DIFF
--- a/spa_sequencer/shot/ops.py
+++ b/spa_sequencer/shot/ops.py
@@ -78,7 +78,9 @@ def ensure_sequencer_frame_visible(context: bpy.types.Context, frame: int):
 class SEQUENCER_OT_shot_new(bpy.types.Operator):
     bl_idname = "sequencer.shot_new"
     bl_label = "New Shot"
-    bl_description = "Create a new shot and append it to the timeline"
+    bl_description = (
+        "Create a new shot at the current position of the playhead on the timeline"
+    )
     bl_options = {"REGISTER", "UNDO"}
 
     template_names = []

--- a/spa_sequencer/shot/ops.py
+++ b/spa_sequencer/shot/ops.py
@@ -216,6 +216,11 @@ class SEQUENCER_OT_shot_new(bpy.types.Operator):
             return {"CANCELLED"}
 
         source_scene = bpy.data.scenes[self.source_scene]
+
+        if self.start_3d < source_scene.frame_start:
+            self.report({"ERROR"}, "3D Start is not in the range of source scene")
+            return {"CANCELLED"}
+
         # Create sequence editor data if needed.
         if not context.scene.sequence_editor:
             context.scene.sequence_editor_create()


### PR DESCRIPTION
- Ad 3D Start Vaue to Operator Pop-Up representing the start frame in the 3D Scene
- Use the timing of the active strip when creating New Shots
- Early Return if 3D Start is out of range

![image](https://github.com/NickTiny/SPArk-sequencer-addon/assets/86638335/e0faaadb-a66a-49d8-b082-40eff772a0bd)
