### PR TITLE
Add Option to use Default Color Managment during Output Scene Render

### DIFF
--- a/spa_sequencer/render/props.py
+++ b/spa_sequencer/render/props.py
@@ -96,6 +96,15 @@ class BatchRenderOptions(bpy.types.PropertyGroup):
         default=False,
         options=set(),
     )
+    output_set_color: bpy.props.BoolProperty(
+        name="Use Default Color Management",
+        description=(
+            "If enabled, override color management settings of output scene, "
+            "to View Transform='Standard' and Look='None' in the sRGB Color Space"
+        ),
+        default=False,
+        options=set(),
+    )
 
     filepath_pattern: bpy.props.StringProperty(
         name="Filepath Pattern",

--- a/spa_sequencer/render/props.py
+++ b/spa_sequencer/render/props.py
@@ -99,8 +99,11 @@ class BatchRenderOptions(bpy.types.PropertyGroup):
     output_set_color: bpy.props.BoolProperty(
         name="Use Default Color Management",
         description=(
-            "If enabled, override color management settings of output scene, "
-            "to View Transform='Standard' and Look='None' in the sRGB Color Space"
+            "If enabled, temporarily override color management settings of output scene. "
+            "View Transform='Standard' and Look='None' in the sRGB Color Space. "
+            "Exposure, Gamma and Curve Mapping are also set to default values. "
+            "CAUTION: If output scene uses AgX, Look value will not be restored "
+            "to it's original value"
         ),
         default=False,
         options=set(),

--- a/spa_sequencer/render/tasks.py
+++ b/spa_sequencer/render/tasks.py
@@ -499,9 +499,13 @@ class SequenceRenderTask(BaseRenderTask):
         if render_options.output_set_color:
             self.overrides.set(self.scene.display_settings, "display_device", "sRGB")
 
-            # TODO The get/set can break if View Transform is set to AGX instead of Standard
+            # The get/set can break if View Transform is set to AGX instead of Standard
             # because looks are called like 'AgX - Low Contrast' and not 'Low Constrast'
-            # should report as bug in blender, lsat checked on hash: `e0e6dc8550f1`
+            # Workaround:
+            # clear look settings if set to AgX because its not intended for VSE use
+            if getattr(self.scene.view_settings, "view_transform") == "AgX":
+                setattr(self.scene.view_settings, "look", "None")
+
             self.overrides.set(self.scene.view_settings, "look", "None")
             self.overrides.set(self.scene.view_settings, "view_transform", "Standard")
             self.overrides.set(self.scene.view_settings, "exposure", 0.0)

--- a/spa_sequencer/render/tasks.py
+++ b/spa_sequencer/render/tasks.py
@@ -235,7 +235,7 @@ class StripRenderTask(BaseRenderTask):
         self.overrides.set(scene.render, "filepath", filepath)
 
     def run(self, context: bpy.types.Context, render_options: BatchRenderOptions):
-        # Ensures functions dependant on current strip/sync are updated during render 
+        # Ensures functions dependant on current strip/sync are updated during render
         get_sync_settings().last_master_strip = self.strip.name
 
         overrides = {"scene": self.scene}
@@ -494,6 +494,22 @@ class SequenceRenderTask(BaseRenderTask):
 
         # Override render settings based on media type
         file_format, file_ext = MEDIA_TYPES_FORMATS["MOVIE"]
+
+        # Ensure Render Scene uses Color Managment Profile same as Default Video Editing file
+        if render_options.output_set_color:
+            self.overrides.set(self.scene.display_settings, "display_device", "sRGB")
+
+            # TODO The get/set can break if View Transform is set to AGX instead of Standard
+            # because looks are called like 'AgX - Low Contrast' and not 'Low Constrast'
+            # should report as bug in blender, lsat checked on hash: `e0e6dc8550f1`
+            self.overrides.set(self.scene.view_settings, "look", "None")
+            self.overrides.set(self.scene.view_settings, "view_transform", "Standard")
+            self.overrides.set(self.scene.view_settings, "exposure", 0.0)
+            self.overrides.set(self.scene.view_settings, "gamma", 1.0)
+            self.overrides.set(self.scene.sequencer_colorspace_settings, "name", "sRGB")
+
+            self.overrides.set(self.scene.view_settings, "use_hdr_view", False)
+            self.overrides.set(self.scene.view_settings, "use_curve_mapping", False)
 
         # Only consider range of video media types.
         sequences = [

--- a/spa_sequencer/render/ui.py
+++ b/spa_sequencer/render/ui.py
@@ -32,6 +32,7 @@ class SEQUENCER_PT_batch_render(bpy.types.Panel):
             col.prop(options, "render_output_scene")
             if options.render_output_scene:
                 col.prop(options, "output_render_filepath_pattern")
+                col.prop(options, "output_set_color")
         self.layout.operator("sequencer.batch_render")
 
 


### PR DESCRIPTION
Adds boolean option to Render Settings, if enabled we enforce the default color managment settings for the Output scene based on the values used in Blender's Default Video Editing template.

If AgX is used in output scene, associated look values are not preserved. This is because in AgX `Look` keys change from `High Contrast` to `AgX - High Contrast` this difference in keys breaks the getter/setter. This changes was made in this [commit](https://projects.blender.org/blender/blender/pulls/111099/files) to blender's source code.

![image](https://github.com/NickTiny/SPArk-sequencer-addon/assets/86638335/aef2c10d-1f70-468b-9971-66f3aee0e10d)
