### PR TITLE
Fix API breaking changes for compatibility with Blender 4.0+

### DIFF
--- a/spa_sequencer/__init__.py
+++ b/spa_sequencer/__init__.py
@@ -17,7 +17,7 @@ bl_info = {
     "name": "SPArk Sequencer",
     "author": "Nick Alberelli & The SPA Studios",
     "description": "Toolset to improve the sequence workflow in Blender.",
-    "blender": (4, 4, 0),
+    "blender": (4, 0, 0),
     "version": (0, 1, 3),
     "location": "",
     "warning": "",

--- a/spa_sequencer/__init__.py
+++ b/spa_sequencer/__init__.py
@@ -17,7 +17,7 @@ bl_info = {
     "name": "SPArk Sequencer",
     "author": "Nick Alberelli & The SPA Studios",
     "description": "Toolset to improve the sequence workflow in Blender.",
-    "blender": (3, 3, 0),
+    "blender": (4, 4, 0),
     "version": (0, 1, 3),
     "location": "",
     "warning": "",

--- a/spa_sequencer/blender_manifest.toml
+++ b/spa_sequencer/blender_manifest.toml
@@ -17,7 +17,7 @@ type = "add-on"
 # https://docs.blender.org/manual/en/dev/advanced/extensions/tags.html
 tags = ["Animation", "Sequencer"]
 
-blender_version_min = "4.2.0"
+blender_version_min = "4.4.0"
 # # Optional: Blender version that the extension does not support, earlier versions are supported.
 # # This can be omitted and defined later on the extensions platform if an issue is found.
 # blender_version_max = "5.1.0"

--- a/spa_sequencer/editorial/core.py
+++ b/spa_sequencer/editorial/core.py
@@ -9,7 +9,7 @@ import bpy
 
 class StripsGroup(NamedTuple):
     group_id: str
-    strips: list[bpy.types.Sequence]
+    strips: list[bpy.types.Strip]
 
     @property
     def frame_start(self):
@@ -28,7 +28,7 @@ class StripsGroup(NamedTuple):
 
 
 def gather_strips_groups_by_regex(
-    strips: list[bpy.types.Sequence], regex_group_id: str
+    strips: list[bpy.types.Strip], regex_group_id: str
 ) -> list[StripsGroup]:
     """
     Build groups of consecutive strips with similar group id - defined by

--- a/spa_sequencer/editorial/ops.py
+++ b/spa_sequencer/editorial/ops.py
@@ -94,7 +94,7 @@ class SEQUENCER_OT_edit_conform_shots_from_panels(bpy.types.Operator):
 
         # Get list of strips from reference channel.
         ref_strips = sorted(
-            [s for s in seq_editor.sequences if s.channel == self.ref_channel],
+            [s for s in seq_editor.strips if s.channel == self.ref_channel],
             key=lambda x: x.frame_final_start,
         )
 
@@ -109,7 +109,7 @@ class SEQUENCER_OT_edit_conform_shots_from_panels(bpy.types.Operator):
             shot_name = shot_naming.build_shot_name((number + 1) * 10, self.shot_prefix)
 
             # Create a new scene strip at frame start of the first ref strip in this group.
-            shot_strip = seq_editor.sequences.new_scene(
+            shot_strip = seq_editor.strips.new_scene(
                 shot_name,
                 shot_scene,
                 self.target_channel,
@@ -209,7 +209,7 @@ class SEQUENCER_OT_edit_conform_shots_from_editorial(bpy.types.Operator):
 
         shot_naming = ShotNaming()
 
-        for strip in seq_editor.sequences:
+        for strip in seq_editor.strips:
 
             if self.ref_channel != 0 and strip.channel != self.ref_channel:
                 continue
@@ -252,7 +252,7 @@ class SEQUENCER_OT_edit_conform_shots_from_editorial(bpy.types.Operator):
                 shot_name = shot_naming.next_shot_name_from_sequences(seq_editor)
 
             # Create a new scene strip using extracted information.
-            shot_strip = seq_editor.sequences.new_scene(
+            shot_strip = seq_editor.strips.new_scene(
                 shot_name, scene, self.target_channel, strip.frame_final_start
             )
             shot_strip.scene_camera = camera

--- a/spa_sequencer/editorial/vse_io/core.py
+++ b/spa_sequencer/editorial/vse_io/core.py
@@ -73,7 +73,7 @@ def sequencer_add_media_func(
 
 
 def strip_apply_frame_offsets(
-    strip: bpy.types.Sequence,
+    strip: bpy.types.Strip,
     frame_final_start: int,
     frame_final_duration: int,
     frame_start_offset: int,

--- a/spa_sequencer/editorial/vse_io/core.py
+++ b/spa_sequencer/editorial/vse_io/core.py
@@ -63,11 +63,11 @@ def sequencer_add_media_func(
     match track.kind:
         case otio.schema.TrackKind.Video:
             if Path(media_filepath).suffix in bpy.path.extensions_image:
-                return seq_editor.sequences.new_image
+                return seq_editor.strips.new_image
             else:
-                return seq_editor.sequences.new_movie
+                return seq_editor.strips.new_movie
         case otio.schema.TrackKind.Audio:
-            return seq_editor.sequences.new_sound
+            return seq_editor.strips.new_sound
         case _:
             raise ValueError("Invalid track kind")
 

--- a/spa_sequencer/editorial/vse_io/ops.py
+++ b/spa_sequencer/editorial/vse_io/ops.py
@@ -78,7 +78,7 @@ class IMPORT_OT_otio(bpy.types.Operator, ImportHelper):
         :param duration: Strip duration.
         :param channel: Strip channel.
         """
-        new_strip = self.seq_editor.sequences.new_effect(
+        new_strip = self.seq_editor.strips.new_effect(
             name=name,
             type="COLOR",
             channel=channel,
@@ -268,7 +268,7 @@ class EXPORT_OT_otio(bpy.types.Operator, ExportHelper):
 
         # Build a map of strips per channels.
         tracks = {}
-        for strip in seq_editor.sequences:
+        for strip in seq_editor.strips:
             if strip.channel not in tracks:
                 tracks[strip.channel] = []
             tracks[strip.channel].append(strip)

--- a/spa_sequencer/editorial/vse_io/ops.py
+++ b/spa_sequencer/editorial/vse_io/ops.py
@@ -69,7 +69,7 @@ class IMPORT_OT_otio(bpy.types.Operator, ImportHelper):
 
     def add_missing_reference_clip(
         self, name: str, frame_start: int, duration: int, channel: int
-    ) -> bpy.types.Sequence:
+    ) -> bpy.types.Strip:
         """Add a strip representing a missing media clip.
 
         :param seq_editor: Sequence editor to add the strip to.
@@ -96,7 +96,7 @@ class IMPORT_OT_otio(bpy.types.Operator, ImportHelper):
         channel: int,
         insert_frame: int,
         duration: int,
-    ) -> bpy.types.Sequence:
+    ) -> bpy.types.Strip:
         """Create a media strip from given `filepath`, based on the given OTIO `clip`.
 
         :param clip: The reference OTIO clip.
@@ -286,10 +286,10 @@ class EXPORT_OT_otio(bpy.types.Operator, ExportHelper):
         return timeline
 
     @staticmethod
-    def track_kind_from_strip(strip: bpy.types.Sequence) -> otio.schema.TrackKind:
+    def track_kind_from_strip(strip: bpy.types.Strip) -> otio.schema.TrackKind:
         """Return otio track kind based on strip type."""
         match type(strip):
-            case bpy.types.SoundSequence:
+            case bpy.types.SoundStrip:
                 return otio.schema.TrackKind.Audio
             case _:
                 return otio.schema.TrackKind.Video
@@ -299,7 +299,7 @@ class EXPORT_OT_otio(bpy.types.Operator, ExportHelper):
         timeline: otio.schema.Timeline,
         track_name: str,
         frame_start: int,
-        strips: list[bpy.types.Sequence],
+        strips: list[bpy.types.Strip],
         timeline_fps: int,
     ) -> otio.schema.Track:
         """Add a new track to `timeline` from input VSE `strips`.
@@ -361,7 +361,7 @@ class EXPORT_OT_otio(bpy.types.Operator, ExportHelper):
         return gap
 
     def add_clip(
-        self, track: otio.schema.Track, strip: bpy.types.Sequence, timeline_fps: int
+        self, track: otio.schema.Track, strip: bpy.types.Strip, timeline_fps: int
     ) -> otio.schema.Clip:
         """Add a new clip on `track` based on input `strip`.
 
@@ -374,13 +374,13 @@ class EXPORT_OT_otio(bpy.types.Operator, ExportHelper):
 
         # Retrieve filepath based on strip type.
         match type(strip):
-            case bpy.types.SoundSequence:
+            case bpy.types.SoundStrip:
                 media_filepath = strip.sound.filepath
-            case bpy.types.ImageSequence:
+            case bpy.types.ImageStrip:
                 media_filepath = os.path.join(
                     strip.directory, strip.elements[0].filename
                 )
-            case bpy.types.MovieSequence:
+            case bpy.types.MovieStrip:
                 media_filepath = strip.filepath
                 media_fps = strip.fps or timeline_fps
             case _:
@@ -424,7 +424,7 @@ class EXPORT_OT_otio(bpy.types.Operator, ExportHelper):
         return clip
 
     @staticmethod
-    def write_aaf_clip_metadata(clip: otio.schema.Clip, strip: bpy.types.Sequence):
+    def write_aaf_clip_metadata(clip: otio.schema.Clip, strip: bpy.types.Strip):
         """
         Write custom AAF metadata to `clip` to identify its source.
         This includes:

--- a/spa_sequencer/render/ops.py
+++ b/spa_sequencer/render/ops.py
@@ -86,7 +86,7 @@ class SEQUENCER_OT_batch_render(bpy.types.Operator):
         # Select scene sequence strips to render
         seqs = [
             seq
-            for seq in self.scene.sequence_editor.sequences
+            for seq in self.scene.sequence_editor.strips
             if isinstance(seq, bpy.types.SceneStrip)
             and (seq.select or not self.render_options.selection_only)
         ]
@@ -103,7 +103,7 @@ class SEQUENCER_OT_batch_render(bpy.types.Operator):
         if self.render_options.output_copy_sound_strips:
             sound_strips = [
                 seq
-                for seq in self.scene.sequence_editor.sequences
+                for seq in self.scene.sequence_editor.strips
                 if isinstance(seq, bpy.types.SoundStrip)
                 and (seq.select or not self.render_options.selection_only)
             ]
@@ -127,8 +127,8 @@ class SEQUENCER_OT_batch_render(bpy.types.Operator):
                 bpy.ops.sequencer.select_all(action="DESELECT")
 
             # Compute channel offset in output scene based on existing content
-            if self.render_options.output_auto_offset_channels and sed.sequences:
-                self.output_channel_offset = max([s.channel for s in sed.sequences])
+            if self.render_options.output_auto_offset_channels and sed.strips:
+                self.output_channel_offset = max([s.channel for s in sed.strips])
         else:
             # Ensure sequence editor is created in output scene.
             output_scene.sequence_editor_create()

--- a/spa_sequencer/render/ops.py
+++ b/spa_sequencer/render/ops.py
@@ -47,7 +47,7 @@ class SEQUENCER_OT_batch_render(bpy.types.Operator):
         self.active_task: Optional[BaseTask] = None
 
         self.output_channel_offset: int = 0
-        self.output_sound_strips: list[bpy.types.SoundSequence] = []
+        self.output_sound_strips: list[bpy.types.SoundStrip] = []
 
         self.cancelled: bool = False
 
@@ -87,7 +87,7 @@ class SEQUENCER_OT_batch_render(bpy.types.Operator):
         seqs = [
             seq
             for seq in self.scene.sequence_editor.sequences
-            if isinstance(seq, bpy.types.SceneSequence)
+            if isinstance(seq, bpy.types.SceneStrip)
             and (seq.select or not self.render_options.selection_only)
         ]
 
@@ -104,7 +104,7 @@ class SEQUENCER_OT_batch_render(bpy.types.Operator):
             sound_strips = [
                 seq
                 for seq in self.scene.sequence_editor.sequences
-                if isinstance(seq, bpy.types.SoundSequence)
+                if isinstance(seq, bpy.types.SoundStrip)
                 and (seq.select or not self.render_options.selection_only)
             ]
             self.output_sound_strips = sorted(

--- a/spa_sequencer/render/tasks.py
+++ b/spa_sequencer/render/tasks.py
@@ -339,7 +339,7 @@ class StripRenderTask(BaseRenderTask):
             for idx in range(scene_strip.frame_final_duration):
                 frame_number = scene_strip.scene.frame_start + idx
                 img_path = scene_strip.scene.render.frame_path(frame=frame_number)
-                strip = sed.sequences.new_image(
+                strip = sed.strips.new_image(
                     name=os.path.basename(bpy.path.abspath(img_path)),
                     filepath=img_path,
                     channel=scene_strip.channel + channel_offset,
@@ -349,7 +349,7 @@ class StripRenderTask(BaseRenderTask):
 
         elif media_type == "MOVIE":
             filepath = scene_strip.scene.render.filepath
-            strip = sed.sequences.new_movie(
+            strip = sed.strips.new_movie(
                 name=os.path.basename(bpy.path.abspath(filepath)),
                 filepath=filepath,
                 channel=scene_strip.channel + channel_offset,
@@ -406,7 +406,7 @@ class CopySoundStripsTask(BaseTask):
 
         # Store original selection from source and dest scenes.
         original_selection = [
-            seq for seq in sed_src.sequences[:] + sed_dst.sequences[:] if seq.select
+            seq for seq in sed_src.strips[:] + sed_dst.strips[:] if seq.select
         ]
 
         # Select only sound strips in source scene.
@@ -487,7 +487,7 @@ class FitResolutionToContentTask(BaseTask):
 
         img_seqs = [
             s
-            for s in self.scene.sequence_editor.sequences
+            for s in self.scene.sequence_editor.strips
             if isinstance(s, (bpy.types.MovieStrip, bpy.types.ImageStrip))
         ]
 
@@ -549,7 +549,7 @@ class SequenceRenderTask(BaseRenderTask):
         # Only consider range of video media types.
         sequences = [
             s
-            for s in self.scene.sequence_editor.sequences
+            for s in self.scene.sequence_editor.strips
             if isinstance(s, (bpy.types.MovieStrip, bpy.types.ImageStrip))
         ]
 

--- a/spa_sequencer/render/tasks.py
+++ b/spa_sequencer/render/tasks.py
@@ -141,7 +141,7 @@ StripRenderTask callback:
  - returns:
     - path to the new media filepath
 """
-StripRenderTaskCallback = Callable[[bpy.types.SceneSequence, str], str]
+StripRenderTaskCallback = Callable[[bpy.types.SceneStrip, str], str]
 
 
 @dataclass
@@ -149,7 +149,7 @@ class StripRenderTask(BaseRenderTask):
     """Strip render task."""
 
     # The strip to render.
-    strip: Optional[bpy.types.SceneSequence] = None
+    strip: Optional[bpy.types.SceneStrip] = None
     # Viewport area.
     viewport_area: Optional[bpy.types.Area] = None
     # Window containing the viewport area.
@@ -319,7 +319,7 @@ class StripRenderTask(BaseRenderTask):
 
     def create_output_media_strip(
         self,
-        scene_strip: bpy.types.SceneSequence,
+        scene_strip: bpy.types.SceneStrip,
         scene: bpy.types.Scene,
         media_type: str,
         frames_handles: int,
@@ -333,7 +333,7 @@ class StripRenderTask(BaseRenderTask):
         sed = scene.sequence_editor
 
         # List created strips and corresponding source frame start/end in scene
-        strips: list[tuple[bpy.types.SceneSequence, int, int]] = []
+        strips: list[tuple[bpy.types.SceneStrip, int, int]] = []
 
         if media_type == "IMAGES":
             for idx in range(scene_strip.frame_final_duration):
@@ -392,7 +392,7 @@ class StripRenderTask(BaseRenderTask):
 class CopySoundStripsTask(BaseTask):
     src_scene: Optional[bpy.types.Scene] = None
     dst_scene: Optional[bpy.types.Scene] = None
-    sound_strips: list[bpy.types.SoundSequence] = field(default_factory=list)
+    sound_strips: list[bpy.types.SoundStrip] = field(default_factory=list)
 
     def run(self, context: bpy.types.Context, render_options: BatchRenderOptions):
         self.status = TaskStatus.FINISHED
@@ -488,7 +488,7 @@ class FitResolutionToContentTask(BaseTask):
         img_seqs = [
             s
             for s in self.scene.sequence_editor.sequences
-            if isinstance(s, (bpy.types.MovieSequence, bpy.types.ImageSequence))
+            if isinstance(s, (bpy.types.MovieStrip, bpy.types.ImageStrip))
         ]
 
         if not img_seqs:
@@ -550,7 +550,7 @@ class SequenceRenderTask(BaseRenderTask):
         sequences = [
             s
             for s in self.scene.sequence_editor.sequences
-            if isinstance(s, (bpy.types.MovieSequence, bpy.types.ImageSequence))
+            if isinstance(s, (bpy.types.MovieStrip, bpy.types.ImageStrip))
         ]
 
         self.scene.frame_start = min(s.frame_final_start for s in sequences)

--- a/spa_sequencer/sequence/ops.py
+++ b/spa_sequencer/sequence/ops.py
@@ -54,7 +54,7 @@ class DOPESHEET_OT_sequence_navigate(bpy.types.Operator):
         # Find a strip that matches the timing
         strips = [
             s
-            for s in master_scene.sequence_editor.sequences
+            for s in master_scene.sequence_editor.strips
             if isinstance(s, bpy.types.SceneStrip) and s.scene == bpy.context.scene
         ]
 

--- a/spa_sequencer/sequence/ops.py
+++ b/spa_sequencer/sequence/ops.py
@@ -160,7 +160,7 @@ class SEQUENCE_OT_check_obj_users_scene(bpy.types.Operator):
         master_scene = get_sync_settings().master_scene
         strips = [
             strip
-            for strip in master_scene.sequence_editor.sequences_all
+            for strip in master_scene.sequence_editor.strips_all
             if strip.type == "SCENE"
         ]
 

--- a/spa_sequencer/sequence/ops.py
+++ b/spa_sequencer/sequence/ops.py
@@ -55,7 +55,7 @@ class DOPESHEET_OT_sequence_navigate(bpy.types.Operator):
         strips = [
             s
             for s in master_scene.sequence_editor.sequences
-            if isinstance(s, bpy.types.SceneSequence) and s.scene == bpy.context.scene
+            if isinstance(s, bpy.types.SceneStrip) and s.scene == bpy.context.scene
         ]
 
         candidates = [

--- a/spa_sequencer/sequence/overlay.py
+++ b/spa_sequencer/sequence/overlay.py
@@ -55,7 +55,7 @@ def shot_baseline_y_pos(context):
 def draw_shot_strip(
     region: bpy.types.Region,
     drawer: OverlayDrawer,
-    strip: bpy.types.SceneSequence,
+    strip: bpy.types.SceneStrip,
     active: bool = False,
 ):
     """
@@ -146,7 +146,7 @@ def draw_sequence_overlay_cb(drawer: OverlayDrawer):
     scene_strips = [
         s
         for s in sync_settings.master_scene.sequence_editor.sequences
-        if isinstance(s, bpy.types.SceneSequence)
+        if isinstance(s, bpy.types.SceneStrip)
         and s.scene == context.scene
         and s != master_strip
     ]

--- a/spa_sequencer/sequence/overlay.py
+++ b/spa_sequencer/sequence/overlay.py
@@ -145,7 +145,7 @@ def draw_sequence_overlay_cb(drawer: OverlayDrawer):
     # List strips using the currently active scene in the master sequence timeline
     scene_strips = [
         s
-        for s in sync_settings.master_scene.sequence_editor.sequences
+        for s in sync_settings.master_scene.sequence_editor.strips
         if isinstance(s, bpy.types.SceneStrip)
         and s.scene == context.scene
         and s != master_strip

--- a/spa_sequencer/sequence/props.py
+++ b/spa_sequencer/sequence/props.py
@@ -27,7 +27,7 @@ class SequenceSettings(bpy.types.PropertyGroup):
         """Set sequence active shot index."""
         # Move to beginning of shot strip in master scene.
         scene = get_sync_settings().master_scene
-        frame = scene.sequence_editor.sequences[idx].frame_final_start
+        frame = scene.sequence_editor.strips[idx].frame_final_start
         scene.frame_set(frame)
 
     shot_active_index: bpy.props.IntProperty(

--- a/spa_sequencer/sequence/ui.py
+++ b/spa_sequencer/sequence/ui.py
@@ -204,8 +204,10 @@ class VIEW3D_PT_sequence(bpy.types.Panel):
                 text="",
             )
             props.camera = context.scene.camera.name
-        row = col.row()
-        row.operator("scene.camera_select", icon="RESTRICT_SELECT_OFF", text="Select")
+        
+        # FIXME : Don't know what this unkown ops is suppose que to do
+        # row = col.row()
+        # row.operator("scene.camera_select", icon="RESTRICT_SELECT_OFF", text="Select")
 
 
 class PROPERTIES_PT_obj_users_scene_check(bpy.types.Panel):

--- a/spa_sequencer/sequence/ui.py
+++ b/spa_sequencer/sequence/ui.py
@@ -101,7 +101,7 @@ class SEQUENCE_UL_shot(bpy.types.UIList):
 
         # Keep only scene strips.
         flt_flags = [
-            self.bitflag_filter_item if isinstance(obj, bpy.types.SceneSequence) else 0
+            self.bitflag_filter_item if isinstance(obj, bpy.types.SceneStrip) else 0
             for obj in objects
         ]
         flt_neworder = []

--- a/spa_sequencer/sequence/ui.py
+++ b/spa_sequencer/sequence/ui.py
@@ -133,7 +133,7 @@ class VIEW3D_PT_sequence(bpy.types.Panel):
         if (
             not master_scene
             or not master_scene.sequence_editor
-            or not master_scene.sequence_editor.sequences
+            or not master_scene.sequence_editor.strips
         ):
             return
 

--- a/spa_sequencer/shared_folders/core.py
+++ b/spa_sequencer/shared_folders/core.py
@@ -174,7 +174,7 @@ def get_scene_sequence_users(
     scene_users = get_scene_users(collection)
     return [
         s
-        for s in sed.sequences
+        for s in sed.strips
         if isinstance(s, bpy.types.SceneStrip) and s.scene in scene_users
     ]
 

--- a/spa_sequencer/shared_folders/core.py
+++ b/spa_sequencer/shared_folders/core.py
@@ -165,7 +165,7 @@ def get_scene_users(collection: bpy.types.Collection) -> list[bpy.types.Scene]:
 
 def get_scene_sequence_users(
     collection: bpy.types.Collection, sed: bpy.types.SequenceEditor
-) -> list[bpy.types.SceneSequence]:
+) -> list[bpy.types.SceneStrip]:
     """Get all scene sequence strips with scenes that uses `collection`.
 
     :param collection: The shared folder.
@@ -175,7 +175,7 @@ def get_scene_sequence_users(
     return [
         s
         for s in sed.sequences
-        if isinstance(s, bpy.types.SceneSequence) and s.scene in scene_users
+        if isinstance(s, bpy.types.SceneStrip) and s.scene in scene_users
     ]
 
 

--- a/spa_sequencer/shared_folders/ops.py
+++ b/spa_sequencer/shared_folders/ops.py
@@ -29,7 +29,7 @@ def get_scenes_from_selected_sequences(
     return [
         s.scene
         for s in sed.sequences
-        if isinstance(s, bpy.types.SceneSequence) and s.select and s.scene
+        if isinstance(s, bpy.types.SceneStrip) and s.select and s.scene
     ]
 
 

--- a/spa_sequencer/shared_folders/ops.py
+++ b/spa_sequencer/shared_folders/ops.py
@@ -28,7 +28,7 @@ def get_scenes_from_selected_sequences(
     """Return scenes from the list of selected sequences in `sed`."""
     return [
         s.scene
-        for s in sed.sequences
+        for s in sed.strips
         if isinstance(s, bpy.types.SceneStrip) and s.select and s.scene
     ]
 

--- a/spa_sequencer/shot/core.py
+++ b/spa_sequencer/shot/core.py
@@ -466,7 +466,7 @@ def reload_strip(strip: bpy.types.Strip):
     # Store sequence editor selection
     selected_strips = [
         (s, s.select_left_handle, s.select_right_handle)
-        for s in scene.sequence_editor.sequences
+        for s in scene.sequence_editor.strips
         if s.select
     ]
 
@@ -543,7 +543,7 @@ def adjust_shot_duration(
     impacted_strips = sorted(
         (
             s
-            for s in sed.sequences
+            for s in sed.strips
             if s.frame_final_start > strip.frame_final_start
             and s.channel == strip.channel
         ),

--- a/spa_sequencer/shot/core.py
+++ b/spa_sequencer/shot/core.py
@@ -457,7 +457,7 @@ def delete_scene(scene: bpy.types.Scene, purge_orphan_datablocks: bool) -> int:
     return del_count
 
 
-def reload_strip(strip: bpy.types.Sequence):
+def reload_strip(strip: bpy.types.Strip):
     """Re-evaluate content length and update `strip` display in the sequencer."""
     # For the strip to re-evaluate its internal scene duration, we need
     # to call the sequencer.reload operator, which runs on selected strips.
@@ -484,7 +484,7 @@ def reload_strip(strip: bpy.types.Sequence):
             strip.select_right_handle = right
 
 
-def adapt_scene_range(strip: bpy.types.SceneSequence):
+def adapt_scene_range(strip: bpy.types.SceneStrip):
     """Ensure `strip`'s internel range is fully contained in the scene its using."""
     # Update internal scene's end frame if exceeding the original one
     new_frame_end = remap_frame_value(strip.frame_final_end - 1, strip)
@@ -496,7 +496,7 @@ def adapt_scene_range(strip: bpy.types.SceneSequence):
 
 
 def adjust_shot_duration(
-    strip: bpy.types.SceneSequence,
+    strip: bpy.types.SceneStrip,
     frame_offset: int,
     from_frame_start: bool = False,
 ) -> bool:
@@ -595,7 +595,7 @@ def adjust_shot_duration(
 
 
 def slip_shot_content(
-    strip: bpy.types.SceneSequence, frame_offset: int, clamp_start: bool = False
+    strip: bpy.types.SceneStrip, frame_offset: int, clamp_start: bool = False
 ):
     """
     Slip `strip` content by `frame_offset`.

--- a/spa_sequencer/shot/naming.py
+++ b/spa_sequencer/shot/naming.py
@@ -223,7 +223,7 @@ class ShotNaming:
         """
         return [
             s
-            for s in sed.sequences
+            for s in sed.strips
             if isinstance(s, bpy.types.SceneStrip) and self.match_name(s.name)
         ]
 

--- a/spa_sequencer/shot/naming.py
+++ b/spa_sequencer/shot/naming.py
@@ -213,7 +213,7 @@ class ShotNaming:
 
     def get_all_shot_strips(
         self, sed: bpy.types.SequenceEditor
-    ) -> list[bpy.types.SceneSequence]:
+    ) -> list[bpy.types.SceneStrip]:
         """
         Get all scene strips in the given sequence editor matching the shot naming
         convention.
@@ -224,7 +224,7 @@ class ShotNaming:
         return [
             s
             for s in sed.sequences
-            if isinstance(s, bpy.types.SceneSequence) and self.match_name(s.name)
+            if isinstance(s, bpy.types.SceneStrip) and self.match_name(s.name)
         ]
 
     def next_shot_name_from_sequences(

--- a/spa_sequencer/shot/ops.py
+++ b/spa_sequencer/shot/ops.py
@@ -23,14 +23,14 @@ from ..utils import register_classes, unregister_classes
 
 
 def get_last_sequence(
-    sequences: list[bpy.types.Sequence],
-) -> Optional[bpy.types.Sequence]:
+    sequences: list[bpy.types.Strip],
+) -> Optional[bpy.types.Strip]:
     """Get the last sequence, i.e. the one with the greatest final frame number."""
     return max(sequences, key=lambda x: x.frame_final_end) if sequences else None
 
 
 def get_last_used_frame(
-    sequences: list[bpy.types.Sequence], scene: bpy.types.Scene
+    sequences: list[bpy.types.Strip], scene: bpy.types.Scene
 ) -> int:
     """
     Get the last used internal frame of `scene` from the given list of `sequences`.
@@ -38,7 +38,7 @@ def get_last_used_frame(
     scene_sequences = [
         s
         for s in sequences
-        if isinstance(s, bpy.types.SceneSequence) and s.scene == scene
+        if isinstance(s, bpy.types.SceneStrip) and s.scene == scene
     ]
 
     if not scene_sequences:
@@ -48,13 +48,13 @@ def get_last_used_frame(
 
 
 def get_selected_scene_sequences(
-    sequences: list[bpy.types.Sequence],
-) -> list[bpy.types.SceneSequence]:
+    sequences: list[bpy.types.Strip],
+) -> list[bpy.types.SceneStrip]:
     """
     :param sequences: The sequences to consider.
     :return: The list of selected scene sequence strips.
     """
-    return [s for s in sequences if isinstance(s, bpy.types.SceneSequence) and s.select]
+    return [s for s in sequences if isinstance(s, bpy.types.SceneStrip) and s.select]
 
 
 def ensure_sequencer_frame_visible(context: bpy.types.Context, frame: int):
@@ -324,10 +324,10 @@ class SEQUENCER_OT_shot_duplicate(bpy.types.Operator):
     @staticmethod
     def duplicate_shot(
         context: bpy.types.Context,
-        strip: bpy.types.SceneSequence,
+        strip: bpy.types.SceneStrip,
         name: str,
         duplicate_scene: bool,
-    ) -> bpy.types.SceneSequence:
+    ) -> bpy.types.SceneStrip:
         sed = strip.id_data.sequence_editor
         if duplicate_scene:
             shot_scene = duplicate_scene(context, strip.scene, name)
@@ -502,12 +502,12 @@ class SEQUENCER_OT_shot_timing_adjust(bpy.types.Operator):
     @staticmethod
     def get_active_strip(
         context: bpy.types.Context,
-    ) -> Optional[bpy.types.SceneSequence]:
+    ) -> Optional[bpy.types.SceneStrip]:
         if context.area.type == "DOPESHEET_EDITOR":
             strip = get_sync_master_strip(use_cache=True)[0]
             return strip if strip and strip.scene == context.window.scene else None
         elif context.scene.sequence_editor and isinstance(
-            context.scene.sequence_editor.active_strip, bpy.types.SceneSequence
+            context.scene.sequence_editor.active_strip, bpy.types.SceneStrip
         ):
             return context.scene.sequence_editor.active_strip
 
@@ -654,11 +654,11 @@ class SEQUENCER_OT_shot_rename(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         return context.scene.sequence_editor and isinstance(
-            cls.active_shot(context), bpy.types.SceneSequence
+            cls.active_shot(context), bpy.types.SceneStrip
         )
 
     @staticmethod
-    def active_shot(context) -> bpy.types.SceneSequence:
+    def active_shot(context) -> bpy.types.SceneStrip:
         return context.scene.sequence_editor.active_strip
 
     def invoke(self, context: bpy.types.Context, event: bpy.types.Event):
@@ -789,7 +789,7 @@ class SEQUENCER_OT_shot_chronological_numbering(bpy.types.Operator):
         scene_strips = [
             strip
             for strip in context.scene.sequence_editor.sequences
-            if isinstance(strip, bpy.types.SceneSequence)
+            if isinstance(strip, bpy.types.SceneStrip)
         ]
 
         if not scene_strips:
@@ -798,7 +798,7 @@ class SEQUENCER_OT_shot_chronological_numbering(bpy.types.Operator):
         tmp_suffix = ".tmp.rename"
         current_name = ""
         scenes_to_rename = set()
-        items_to_rename: dict[bpy.types.SceneSequence, tuple[str, bool]] = dict()
+        items_to_rename: dict[bpy.types.SceneStrip, tuple[str, bool]] = dict()
 
         # Go through the shots chronologically (sorted by the start frame)
         sorted_scene_strips = sorted(scene_strips, key=lambda x: x.frame_final_start)

--- a/spa_sequencer/shot/ops.py
+++ b/spa_sequencer/shot/ops.py
@@ -237,7 +237,7 @@ class SEQUENCER_OT_shot_new(bpy.types.Operator):
             self.report({"ERROR"}, "3D Start is not in the range of source scene")
             return {"CANCELLED"}
 
-        sequences = context.scene.sequence_editor.sequences
+        sequences = context.scene.sequence_editor.strips
         frame_offset_start = 0
 
         # Source scene handling.
@@ -335,10 +335,10 @@ class SEQUENCER_OT_shot_duplicate(bpy.types.Operator):
             shot_scene = strip.scene
 
         # Find the frame where to insert the duplicated strip
-        insert_frame = get_last_sequence(sed.sequences).frame_final_end
+        insert_frame = get_last_sequence(sed.strips).frame_final_end
 
         # Create new strip
-        new_strip = sed.sequences.new_scene(
+        new_strip = sed.strips.new_scene(
             name, shot_scene, strip.channel, insert_frame
         )
 
@@ -346,7 +346,7 @@ class SEQUENCER_OT_shot_duplicate(bpy.types.Operator):
 
         if not duplicate_scene:
             new_strip.scene_camera = strip.scene_camera
-            frame_offset = get_last_used_frame(sed.sequences, shot_scene)
+            frame_offset = get_last_used_frame(sed.strips, shot_scene)
             slip_shot_content(new_strip, frame_offset)
         else:
             new_strip.scene_camera = strip.scene.camera
@@ -357,7 +357,7 @@ class SEQUENCER_OT_shot_duplicate(bpy.types.Operator):
         sed = context.scene.sequence_editor
 
         new_strips = []
-        for strip in get_selected_scene_sequences(sed.sequences):
+        for strip in get_selected_scene_sequences(sed.strips):
             name = shot_naming.next_shot_name_from_sequences(sed)
             new_strip = self.duplicate_shot(context, strip, name, self.duplicate_scene)
             new_strips.append(new_strip)
@@ -413,7 +413,7 @@ class SEQUENCER_OT_shot_delete(bpy.types.Operator):
 
     def invoke(self, context: bpy.types.Context, event):
         self.strips = get_selected_scene_sequences(
-            context.scene.sequence_editor.sequences
+            context.scene.sequence_editor.strips
         )
         if not self.strips:
             self.report({"ERROR"}, "No selected shots")
@@ -442,7 +442,7 @@ class SEQUENCER_OT_shot_delete(bpy.types.Operator):
 
     def execute(self, context: bpy.types.Context):
         deleted_datablocks = 0
-        strips = get_selected_scene_sequences(context.scene.sequence_editor.sequences)
+        strips = get_selected_scene_sequences(context.scene.sequence_editor.strips)
 
         # Store scenes to delete in a set to avoid duplicates
         scenes = set()
@@ -450,7 +450,7 @@ class SEQUENCER_OT_shot_delete(bpy.types.Operator):
         for strip in strips:
             if strip.scene and self.delete_scenes:
                 scenes.add(strip.scene)
-            context.scene.sequence_editor.sequences.remove(strip)
+            context.scene.sequence_editor.strips.remove(strip)
 
         # Delete the scenes
         for scene in scenes:
@@ -701,7 +701,7 @@ class SEQUENCER_OT_shot_rename(bpy.types.Operator):
             shot_strip.name,
             current_name,
             "SEQUENCE",
-            context.scene.sequence_editor.sequences,
+            context.scene.sequence_editor.strips,
         )
 
         # Scene renaming details.
@@ -723,7 +723,7 @@ class SEQUENCER_OT_shot_rename(bpy.types.Operator):
         # Evaluate shot strip renaming.
         if new_name != shot_strip.name:
             # Ensure strip name is available.
-            if new_name in context.scene.sequence_editor.sequences:
+            if new_name in context.scene.sequence_editor.strips:
                 self.report({"ERROR"}, f"Shot '{new_name}' already exists")
                 return {"CANCELLED"}
             do_rename_strip = True
@@ -788,7 +788,7 @@ class SEQUENCER_OT_shot_chronological_numbering(bpy.types.Operator):
     def execute(self, context: bpy.types.Context):
         scene_strips = [
             strip
-            for strip in context.scene.sequence_editor.sequences
+            for strip in context.scene.sequence_editor.strips
             if isinstance(strip, bpy.types.SceneStrip)
         ]
 

--- a/spa_sequencer/shot/ops.py
+++ b/spa_sequencer/shot/ops.py
@@ -319,7 +319,7 @@ class SEQUENCER_OT_shot_duplicate(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context: bpy.types.Context):
-        return bool(context.selected_sequences)
+        return bool(context.selected_strips)
 
     @staticmethod
     def duplicate_shot(
@@ -409,7 +409,7 @@ class SEQUENCER_OT_shot_delete(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context: bpy.types.Context):
-        return bool(context.selected_sequences)
+        return bool(context.selected_strips)
 
     def invoke(self, context: bpy.types.Context, event):
         self.strips = get_selected_scene_sequences(

--- a/spa_sequencer/sync/core.py
+++ b/spa_sequencer/sync/core.py
@@ -9,7 +9,7 @@ import bpy
 from ..utils import register_classes, unregister_classes
 
 
-SequenceType = Type[bpy.types.Sequence]
+SequenceType = Type[bpy.types.Strip]
 
 
 class TimelineSyncSettings(bpy.types.PropertyGroup):
@@ -158,7 +158,7 @@ def _scene_frame_set_optimized(
 scene_frame_set = _scene_frame_set_optimized
 
 
-def remap_frame_value(frame: int, scene_strip: bpy.types.SceneSequence) -> int:
+def remap_frame_value(frame: int, scene_strip: bpy.types.SceneStrip) -> int:
     """Remap `frame` in `scene_strip`'s underlying scene reference.
 
     :param frame: The frame to remap
@@ -170,10 +170,10 @@ def remap_frame_value(frame: int, scene_strip: bpy.types.SceneSequence) -> int:
 
 def get_strips_at_frame(
     frame: int,
-    strips: list[bpy.types.Sequence],
+    strips: list[bpy.types.Strip],
     type_filter: Union[SequenceType, tuple[SequenceType, ...]] = None,
     skip_muted: bool = True,
-) -> list[bpy.types.Sequence]:
+) -> list[bpy.types.Strip]:
     """
     Get all strips containing the given `frame` within their final range.
 
@@ -198,7 +198,7 @@ def get_scene_strip_at_frame(
     frame: int,
     sequence_editor: bpy.types.SequenceEditor,
     skip_muted: bool = True,
-) -> tuple[Union[bpy.types.SceneSequence, None], int]:
+) -> tuple[Union[bpy.types.SceneStrip, None], int]:
     """
     Get the scene strip at `frame` in `sequence_editor`'s strips with the highest
     channel number.
@@ -217,7 +217,7 @@ def get_scene_strip_at_frame(
         muted_channels = [idx for idx, channel in enumerate(channels) if channel.mute]
         strips = [strip for strip in strips if not strip.channel in muted_channels]
 
-    strips = get_strips_at_frame(frame, strips, bpy.types.SceneSequence, skip_muted)
+    strips = get_strips_at_frame(frame, strips, bpy.types.SceneStrip, skip_muted)
 
     if not strips:
         return None, frame
@@ -225,7 +225,7 @@ def get_scene_strip_at_frame(
     strip = sorted(strips, key=lambda x: x.channel)[-1]
 
     # Help type checking: strip can only be a SceneSequence here
-    assert isinstance(strip, bpy.types.SceneSequence)
+    assert isinstance(strip, bpy.types.SceneStrip)
 
     # Only consider scene strips with a valid scene
     if not strip.scene:
@@ -341,7 +341,7 @@ def set_gpencil_mode_safe(
 
 def get_sync_master_strip(
     use_cache: bool = False,
-) -> tuple[Union[bpy.types.SceneSequence, None], int]:
+) -> tuple[Union[bpy.types.SceneStrip, None], int]:
     """
     Return the scene strip currently used by the Timeline Synchronization.
 
@@ -364,7 +364,7 @@ def get_sync_master_strip(
     )
 
 
-def update_preview_range(scene_strip: bpy.types.SceneSequence):
+def update_preview_range(scene_strip: bpy.types.SceneStrip):
     """Update `scene_strip`'s scene preview range to match `scene_strip`'s range.
 
     :param scene_strip: The scene strip to update.
@@ -600,7 +600,7 @@ def on_load_post(*args):
         if scene.sequence_editor:
             seq_editor = scene.sequence_editor
             if seq_editor and any(
-                isinstance(s, bpy.types.SceneSequence) for s in seq_editor.sequences
+                isinstance(s, bpy.types.SceneStrip) for s in seq_editor.sequences
             ):
                 sync_settings.master_scene = scene
                 sync_settings.enabled = True

--- a/spa_sequencer/sync/core.py
+++ b/spa_sequencer/sync/core.py
@@ -9,7 +9,7 @@ import bpy
 from ..utils import register_classes, unregister_classes
 
 
-SequenceType = Type[bpy.types.Strip]
+StripType = Type[bpy.types.Strip]
 
 
 class TimelineSyncSettings(bpy.types.PropertyGroup):
@@ -171,7 +171,7 @@ def remap_frame_value(frame: int, scene_strip: bpy.types.SceneStrip) -> int:
 def get_strips_at_frame(
     frame: int,
     strips: list[bpy.types.Strip],
-    type_filter: Union[SequenceType, tuple[SequenceType, ...]] = None,
+    type_filter: Union[StripType, tuple[StripType, ...]] = None,
     skip_muted: bool = True,
 ) -> list[bpy.types.Strip]:
     """

--- a/spa_sequencer/sync/core.py
+++ b/spa_sequencer/sync/core.py
@@ -209,7 +209,7 @@ def get_scene_strip_at_frame(
     :returns: The scene strip (or None) and the frame in underlying scene's reference
     """
 
-    strips = sequence_editor.sequences
+    strips = sequence_editor.strips
     channels = sequence_editor.channels
 
     if skip_muted:
@@ -354,7 +354,7 @@ def get_sync_master_strip(
 
     if use_cache:
         return (
-            master_scene.sequence_editor.sequences.get(settings.last_master_strip),
+            master_scene.sequence_editor.strips.get(settings.last_master_strip),
             settings.last_strip_scene_frame,
         )
 
@@ -433,7 +433,7 @@ def sync_system_update(context: bpy.types.Context, force: bool = False):
 
         # Get sync master strip.
         # NOTE: use cached value as a convenient shortcut to avoid computing it again.
-        strip = master_scene.sequence_editor.sequences.get(
+        strip = master_scene.sequence_editor.strips.get(
             sync_settings.last_master_strip
         )
 
@@ -512,7 +512,7 @@ def sync_system_update(context: bpy.types.Context, force: bool = False):
 
     # Update cached values
     sync_settings.last_master_strip = strip.name
-    sync_settings.last_master_strip_idx = master_scene.sequence_editor.sequences.find(
+    sync_settings.last_master_strip_idx = master_scene.sequence_editor.strips.find(
         strip.name
     )
     sync_settings.last_strip_scene_frame = inner_frame
@@ -569,7 +569,7 @@ def update_sync_cache_from_current_state():
     strip, frame = get_sync_master_strip()
     sync_settings.last_master_strip = strip.name if strip else ""
     sync_settings.last_master_strip_idx = (
-        sync_settings.master_scene.sequence_editor.sequences.find(strip.name)
+        sync_settings.master_scene.sequence_editor.strips.find(strip.name)
         if strip
         else -1
     )
@@ -600,7 +600,7 @@ def on_load_post(*args):
         if scene.sequence_editor:
             seq_editor = scene.sequence_editor
             if seq_editor and any(
-                isinstance(s, bpy.types.SceneStrip) for s in seq_editor.sequences
+                isinstance(s, bpy.types.SceneStrip) for s in seq_editor.strips
             ):
                 sync_settings.master_scene = scene
                 sync_settings.enabled = True


### PR DESCRIPTION
There were breaking changes in VSE API for 4.4.
Mainly : `sequence` became `strip` almost everywhere
https://developer.blender.org/docs/release_notes/4.4/python_api/#video-sequencer-strips

Until blender 5.0, the deprecated attributes still work, but that was not the case for the type-hints, already using `bpy.types.Strips` and the like. This is fixed by the first commit of the batch of this pull-request, to restore the addon compatibility with 4.4.

I did the rest of the changes as well to ensure future compatibility with Blender 5.0.
Basically just monkey work of big search and replaces, still executed one by one to avoid false-positive.

This time I thought to not bump the addon version to let you do it in your own commit 😉 
(Still bumped the Blender version since it will not be retro-compatible anyway)

Note: After the first compatibility fixes, I noticed an error loop in UI on a `layout.operator` in `sequence/ui` -> line 208. Not knowing how to fix, I just commented it.
