### PR TITLE
Install Add-On During Tests

### DIFF
--- a/scripts/run_pytest.py
+++ b/scripts/run_pytest.py
@@ -1,16 +1,56 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (C) 2023, The SPA Studios. All rights reserved.
 
+"""
+Pytest runner executed inside Blender.
+
+Usage::
+
+    local/blender/blender -b --factory-startup -P scripts/run_pytest.py -- [pytest_args]
+
+Sets up the addon source directory as a local extension repository,
+refreshes extensions so Blender discovers the addon, then runs pytest.
+All arguments after ``--`` are forwarded to ``pytest.main()``.
+"""
+
 import sys
+from pathlib import Path
 
-import pytest
+import bpy
+import addon_utils
+
+try:
+    import pytest
+except ImportError:
+    print(
+        "ERROR: pytest is not installed in Blender's Python.\n"
+        "Install it into Blender's bundled Python, e.g.:\n"
+        "  local/blender/5.1/python/bin/python3.11 -m pip install pytest",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTS_FOLDER = str(REPO_ROOT / "tests")
+ADDON_DIR = str(REPO_ROOT)
+REPO_MODULE = "spark_dev"
 
 
-TESTS_FOLDER = "tests"
+def setup_extension():
+    """Register the addon source as a local extension repository."""
+    repos = bpy.context.preferences.extensions.repos
+    repo = repos.new(
+        name="SPArk Dev",
+        module=REPO_MODULE,
+        custom_directory=ADDON_DIR,
+    )
+    repo.use_custom_directory = True
+    addon_utils.extensions_refresh(ensure_wheels=True)
 
 
 def main(args):
-    """Run tests and return pytest's exit code."""
+    """Set up extension environment, then run tests."""
+    setup_extension()
     return pytest.main([TESTS_FOLDER] + args)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 import bpy
 
-from utils import import_spa_sequencer_module
+from utils import import_spa_sequencer_module, get_module_name
 import_spa_sequencer_module()
 
 @pytest.fixture()
@@ -13,7 +13,7 @@ def addon():
     """Fixture loading/enabling the addon."""
     import addon_utils
 
-    return addon_utils.enable("spa_sequencer", persistent=True, default_set=True)
+    return addon_utils.enable(get_module_name(), persistent=True, default_set=True)
 
 
 @pytest.fixture()


### PR DESCRIPTION
This fixes an issue where adding the `--factory-statup` argument to the test instructions in `CONTRIBUTING.md` was inaccurate.

Previously developers were responsible for installing the add-on before tests. This can cause issues if the add-on that is installed is not the one being currently developed depending on the Blender version launched. 

With this change we are now installing the add-on on top of blender's default factory preferences ensuring a clean testing environment on each run.