### PR TITLE
Fix: Blender 5.1 Sequencer API Changes

### DIFF
--- a/spa_sequencer/editorial/core.py
+++ b/spa_sequencer/editorial/core.py
@@ -14,12 +14,12 @@ class StripsGroup(NamedTuple):
     @property
     def frame_start(self):
         """First frame of that group."""
-        return self.strips[0].frame_final_start if self.strips else 0
+        return self.strips[0].left_handle if self.strips else 0
 
     @property
     def frame_end(self):
         """Last frame of that group."""
-        return self.strips[-1].frame_final_end if self.strips else 0
+        return self.strips[-1].right_handle if self.strips else 0
 
     @property
     def frame_duration(self):

--- a/spa_sequencer/editorial/ops.py
+++ b/spa_sequencer/editorial/ops.py
@@ -7,7 +7,7 @@ import bpy
 
 
 from ..shot.naming import ShotNaming, ShotPrefix
-from ..shot.core import slip_shot_content, set_shot_duration
+from ..shot.core import slip_shot_content
 from ..utils import register_classes, unregister_classes, get_edit_scene
 
 from ..editorial.core import gather_strips_groups_by_regex
@@ -116,7 +116,7 @@ class SEQUENCER_OT_edit_conform_shots_from_panels(bpy.types.Operator):
                 group.frame_start,
             )
             # Match the duration of the whole group.
-            set_shot_duration(shot_strip, group.frame_duration)
+            shot_strip.duration = group.frame_duration
             # Adjust internal offset to target the correct range within the strip's scene.
             slip_shot_content(shot_strip, shot_strip.left_handle)
             # Assign active camera of the scene.
@@ -257,7 +257,7 @@ class SEQUENCER_OT_edit_conform_shots_from_editorial(bpy.types.Operator):
             )
             shot_strip.scene_camera = camera
             # Adjust timing.
-            set_shot_duration(shot_strip, strip.duration)
+            shot_strip.duration = strip.duration
             shot_strip.left_handle = strip.left_handle
             start_offset = frame_start + strip.left_handle_offset - 1
             slip_shot_content(shot_strip, start_offset)

--- a/spa_sequencer/editorial/ops.py
+++ b/spa_sequencer/editorial/ops.py
@@ -7,7 +7,7 @@ import bpy
 
 
 from ..shot.naming import ShotNaming, ShotPrefix
-from ..shot.core import slip_shot_content
+from ..shot.core import slip_shot_content, set_shot_duration
 from ..utils import register_classes, unregister_classes, get_edit_scene
 
 from ..editorial.core import gather_strips_groups_by_regex
@@ -95,7 +95,7 @@ class SEQUENCER_OT_edit_conform_shots_from_panels(bpy.types.Operator):
         # Get list of strips from reference channel.
         ref_strips = sorted(
             [s for s in seq_editor.strips if s.channel == self.ref_channel],
-            key=lambda x: x.frame_final_start,
+            key=lambda x: x.left_handle,
         )
 
         # Build strip groups based on shot regex.
@@ -116,9 +116,9 @@ class SEQUENCER_OT_edit_conform_shots_from_panels(bpy.types.Operator):
                 group.frame_start,
             )
             # Match the duration of the whole group.
-            shot_strip.frame_final_duration = group.frame_duration
+            set_shot_duration(shot_strip, group.frame_duration)
             # Adjust internal offset to target the correct range within the strip's scene.
-            slip_shot_content(shot_strip, shot_strip.frame_final_start)
+            slip_shot_content(shot_strip, shot_strip.left_handle)
             # Assign active camera of the scene.
             shot_strip.scene_camera = shot_scene.camera
 
@@ -226,7 +226,7 @@ class SEQUENCER_OT_edit_conform_shots_from_editorial(bpy.types.Operator):
             frame_end = int(
                 strip.get(
                     STRIP_PROP_SOURCE_FRAME_END,
-                    (frame_start + strip.frame_duration - 1),
+                    (frame_start + strip.content_duration - 1),
                 )
             )
 
@@ -253,21 +253,21 @@ class SEQUENCER_OT_edit_conform_shots_from_editorial(bpy.types.Operator):
 
             # Create a new scene strip using extracted information.
             shot_strip = seq_editor.strips.new_scene(
-                shot_name, scene, self.target_channel, strip.frame_final_start
+                shot_name, scene, self.target_channel, strip.left_handle
             )
             shot_strip.scene_camera = camera
             # Adjust timing.
-            shot_strip.frame_final_duration = strip.frame_final_duration
-            shot_strip.frame_final_start = strip.frame_final_start
-            start_offset = frame_start + strip.frame_offset_start - 1
+            set_shot_duration(shot_strip, strip.duration)
+            shot_strip.left_handle = strip.left_handle
+            start_offset = frame_start + strip.left_handle_offset - 1
             slip_shot_content(shot_strip, start_offset)
 
             # Detect if shot is exceeding initial rendering range.
             if self.freeze_frame_handles_warning:
                 frame_start = remap_frame_value(
-                    shot_strip.frame_final_start, shot_strip
+                    shot_strip.left_handle, shot_strip
                 )
-                frame_end = remap_frame_value(shot_strip.frame_final_end, shot_strip)
+                frame_end = remap_frame_value(shot_strip.right_handle, shot_strip)
                 if frame_start < source_frame_start or frame_end > source_frame_end:
                     shot_strip.color_tag = "COLOR_02"
 

--- a/spa_sequencer/editorial/vse_io/core.py
+++ b/spa_sequencer/editorial/vse_io/core.py
@@ -72,11 +72,11 @@ def sequencer_add_media_func(
             raise ValueError("Invalid track kind")
 
 
-def strip_apply_frame_offsets(
+def strip_apply_handle_offsets(
     strip: bpy.types.Strip,
-    frame_final_start: int,
-    frame_final_duration: int,
-    frame_start_offset: int,
+    left_handle: int,
+    duration: int,
+    left_handle_offset: int,
 ):
     """
     Apply strip external and internal offsets in the correct order to get
@@ -84,9 +84,9 @@ def strip_apply_frame_offsets(
     given values, without changing the strip's channel.
 
     :param strip: The strip to apply offsets to.
-    :param frame_final_start: The target final frame start.
-    :param frame_final_duration: The target final frame duration.
-    :param frame_start_offset: The target frame start offset.
+    :param left_handle: The target final frame start.
+    :param duration: The target final frame duration.
+    :param left_handle_offset: The target frame start offset.
     """
 
     # This requires this sequence of actions in this order
@@ -96,18 +96,18 @@ def strip_apply_frame_offsets(
     # 1. Restore "external" start/end properties.
     # NOTE: adjust frame end first to be compliant with Blender internal checks
     #       to avoid start > end.
-    final_frame_end = frame_final_start + frame_final_duration
-    strip.frame_final_end = final_frame_end
-    strip.frame_final_start = frame_final_start
+    final_frame_end = left_handle + duration
+    strip.right_handle = final_frame_end
+    strip.left_handle = left_handle
 
     # Blender might have moved the strip to another
     # channel to avoid overwrite - store this.
     auto_channel = strip.channel
     # 2. Apply strip "internal" offset.
-    strip.frame_start -= frame_start_offset
+    strip.content_start -= left_handle_offset
     # 3. Restore "external" properties again.
-    strip.frame_final_end = final_frame_end
-    strip.frame_final_start = frame_final_start
+    strip.right_handle = final_frame_end
+    strip.left_handle = left_handle
     # 4. Counter any change of channel from 3.
     #    by resetting the auto channel from 1.
     if strip.channel != auto_channel:

--- a/spa_sequencer/editorial/vse_io/ops.py
+++ b/spa_sequencer/editorial/vse_io/ops.py
@@ -14,7 +14,7 @@ from ...utils import register_classes, unregister_classes, get_edit_scene
 from .core import (
     get_media_reference_filepath,
     sequencer_add_media_func,
-    strip_apply_frame_offsets,
+    strip_apply_handle_offsets,
 )
 
 
@@ -125,7 +125,7 @@ class IMPORT_OT_otio(bpy.types.Operator, ImportHelper):
             frame_start=insert_frame,
         )
         offset_start = otio.opentime.to_frames(clip.source_range.start_time)
-        strip_apply_frame_offsets(strip, insert_frame, duration, offset_start)
+        strip_apply_handle_offsets(strip, insert_frame, duration, offset_start)
         return strip
 
     def transcribe_otio_source_clip(
@@ -330,7 +330,7 @@ class EXPORT_OT_otio(bpy.types.Operator, ExportHelper):
         track.kind = kinds.pop()
 
         # Sort strips by frame start.
-        sorted_strip = sorted(strips, key=lambda x: x.frame_final_start)
+        sorted_strip = sorted(strips, key=lambda x: x.left_handle)
         # Initialize insert time using first strip start frame.
         # Getting first element is safe, sequences can not be empty here.
         insert_time = frame_start
@@ -338,12 +338,12 @@ class EXPORT_OT_otio(bpy.types.Operator, ExportHelper):
         # Iterate over strips.
         for strip in sorted_strip:
             # Add a gap if the clip is not starting right at current insertion time.
-            if insert_time < strip.frame_final_start:
-                gap_duration = strip.frame_final_start - insert_time
+            if insert_time < strip.left_handle:
+                gap_duration = strip.left_handle - insert_time
                 self.add_gap(track, insert_time, gap_duration, timeline_fps)
             # Add a clip to the track to represent current strip.
             self.add_clip(track, strip, timeline_fps)
-            insert_time = strip.frame_final_end
+            insert_time = strip.right_handle
 
         timeline.tracks.append(track)
         return track
@@ -408,12 +408,12 @@ class EXPORT_OT_otio(bpy.types.Operator, ExportHelper):
 
         # Compute strip internal offset.
         # TODO: Test for the sign of this offset when importing in other software.
-        offset = strip.frame_final_start - strip.frame_start
+        offset = strip.left_handle - strip.content_start
         clip = otio.schema.Clip(
             name=strip.name,
             source_range=otio.opentime.TimeRange(
                 start_time=RationalTime(offset, timeline_fps),
-                duration=RationalTime(strip.frame_final_duration, timeline_fps),
+                duration=RationalTime(strip.duration, timeline_fps),
             ),
         )
 
@@ -421,7 +421,7 @@ class EXPORT_OT_otio(bpy.types.Operator, ExportHelper):
             media_filepath,
             available_range=TimeRange(
                 start_time=RationalTime(0, media_fps),
-                duration=RationalTime(strip.frame_duration, media_fps),
+                duration=RationalTime(strip.content_duration, media_fps),
             ),
         )
 

--- a/spa_sequencer/render/ops.py
+++ b/spa_sequencer/render/ops.py
@@ -93,7 +93,7 @@ class SEQUENCER_OT_batch_render(bpy.types.Operator):
         ]
 
         # Create render tasks
-        for seq in sorted(seqs, key=lambda x: x.frame_final_start):
+        for seq in sorted(seqs, key=lambda x: x.left_handle):
             self.tasks.append(StripRenderTask(strip=seq, is_modal=render_op_invoke))
 
         # Early return if output scene is not set.
@@ -109,7 +109,7 @@ class SEQUENCER_OT_batch_render(bpy.types.Operator):
                 and (seq.select or not self.render_options.selection_only)
             ]
             self.output_sound_strips = sorted(
-                sound_strips, key=lambda x: x.frame_final_start
+                sound_strips, key=lambda x: x.left_handle
             )
             if self.output_sound_strips:
                 self.tasks.append(

--- a/spa_sequencer/render/tasks.py
+++ b/spa_sequencer/render/tasks.py
@@ -166,8 +166,8 @@ class StripRenderTask(BaseRenderTask):
         scene = self.scene
 
         # Override scene's internal range to match strip's range.
-        frame_start = remap_frame_value(strip.frame_final_start, strip)
-        frame_end = frame_start + strip.frame_final_duration - 1
+        frame_start = remap_frame_value(strip.left_handle, strip)
+        frame_end = frame_start + strip.duration - 1
         # Apply frame handles to range.
         if render_options.media_type == "MOVIE":
             frame_start -= render_options.frames_handles
@@ -308,14 +308,14 @@ class StripRenderTask(BaseRenderTask):
         strips: list[tuple[bpy.types.SceneStrip, int, int]] = []
 
         if media_type == "IMAGES":
-            for idx in range(scene_strip.frame_final_duration):
+            for idx in range(scene_strip.duration):
                 frame_number = scene_strip.scene.frame_start + idx
                 img_path = scene_strip.scene.render.frame_path(frame=frame_number)
                 strip = sed.strips.new_image(
                     name=os.path.basename(bpy.path.abspath(img_path)),
                     filepath=img_path,
                     channel=scene_strip.channel + channel_offset,
-                    frame_start=scene_strip.frame_final_start + idx,
+                    frame_start=scene_strip.left_handle + idx,
                 )
                 strips.append((strip, frame_number, frame_number))
 
@@ -325,7 +325,7 @@ class StripRenderTask(BaseRenderTask):
                 name=os.path.basename(bpy.path.abspath(filepath)),
                 filepath=filepath,
                 channel=scene_strip.channel + channel_offset,
-                frame_start=scene_strip.frame_final_start,
+                frame_start=scene_strip.left_handle,
             )
 
             start_handle = frames_handles
@@ -335,13 +335,13 @@ class StripRenderTask(BaseRenderTask):
                 # This is done by getting the difference between:
                 #  the rendered clip duration
                 #  and the scene strip's duration + end frame handle's duration.
-                start_handle = strip.frame_duration - (
-                    scene_strip.frame_final_duration + frames_handles
+                start_handle = strip.content_duration - (
+                    scene_strip.duration + frames_handles
                 )
 
-            strip.frame_offset_start = start_handle
-            strip.frame_offset_end = frames_handles
-            strip.frame_start -= start_handle
+            strip.left_handle_offset = start_handle
+            strip.right_handle_offset = frames_handles
+            strip.content_start -= start_handle
             strips.append(
                 (strip, scene_strip.scene.frame_start, scene_strip.scene.frame_end)
             )
@@ -426,13 +426,13 @@ class CopySoundStripsTask(BaseTask):
         # To handle pasting such strips, make the copy happen at frame 0, and slide them
         # from the proper offset afterwards.
         self.overrides.set(self.dst_scene, "frame_current", 0)
-        frame_offset = self.sound_strips[0].frame_final_start
+        handle_offset = self.sound_strips[0].left_handle
 
         try:
             # Call paste operator with scene context override.
             with context.temp_override(**paste_op_ctx_override):
                 bpy.ops.sequencer.paste()
-                bpy.ops.transform.seq_slide(value=(frame_offset, 0))
+                bpy.ops.transform.seq_slide(value=(handle_offset, 0))
         finally:
             self.overrides.revert()
 
@@ -525,8 +525,8 @@ class SequenceRenderTask(BaseRenderTask):
             if isinstance(s, (bpy.types.MovieStrip, bpy.types.ImageStrip))
         ]
 
-        self.scene.frame_start = min(s.frame_final_start for s in sequences)
-        self.scene.frame_end = max(s.frame_final_end for s in sequences) - 1
+        self.scene.frame_start = min(s.left_handle for s in sequences)
+        self.scene.frame_end = max(s.right_handle for s in sequences) - 1
 
         # Filepath: add extension to avoid auto frame range suffix
         filepath += f".{file_ext}"

--- a/spa_sequencer/sequence/ops.py
+++ b/spa_sequencer/sequence/ops.py
@@ -62,9 +62,9 @@ class DOPESHEET_OT_sequence_navigate(bpy.types.Operator):
             s
             for s in strips
             if (
-                remap_frame_value(s.frame_final_start, s)
+                remap_frame_value(s.left_handle, s)
                 <= self.frame
-                <= remap_frame_value(s.frame_final_end, s)
+                <= remap_frame_value(s.right_handle, s)
             )
         ]
 
@@ -74,7 +74,7 @@ class DOPESHEET_OT_sequence_navigate(bpy.types.Operator):
 
         # Update master scene current frame to enter target strip.
         if strip and strip != master_strip:
-            master_scene.frame_set(strip.frame_final_start)
+            master_scene.frame_set(strip.left_handle)
 
         # Set frame_current directly for context's active scene.
         # This proves to be enough and reacts better than frame_set which
@@ -164,13 +164,13 @@ class SEQUENCE_OT_check_obj_users_scene(bpy.types.Operator):
             if strip.type == "SCENE"
         ]
 
-        for strip in sorted(strips, key=lambda f: f.frame_final_start):
+        for strip in sorted(strips, key=lambda f: f.left_handle):
             scene_msg = f" - Scene '{strip.scene.name}' from strips:\n"
             if scene_msg not in info_msg:
                 info_msg += scene_msg
             info_msg += (
                 f"   - {strip.name} "
-                f"[{strip.frame_final_start}, {strip.frame_final_end}]\n"
+                f"[{strip.left_handle}, {strip.right_handle}]\n"
             )
 
         report = f"Object '{obj.name}' is used in '{master_scene.name}' by:\n{info_msg}"

--- a/spa_sequencer/sequence/overlay.py
+++ b/spa_sequencer/sequence/overlay.py
@@ -69,8 +69,8 @@ def draw_shot_strip(
     strip_height = ui_scaled(STRIP_HEIGHT)
     base_y_pos = shot_baseline_y_pos(bpy.context)
 
-    frame_in = remap_frame_value(strip.frame_final_start, strip)
-    frame_out = remap_frame_value(strip.frame_final_end, strip)
+    frame_in = remap_frame_value(strip.left_handle, strip)
+    frame_out = remap_frame_value(strip.right_handle, strip)
     frame_in = region.view2d.view_to_region(frame_in, 0, clip=False)[0]
     frame_out = region.view2d.view_to_region(frame_out, 0, clip=False)[0]
     duration = frame_out - frame_in
@@ -249,8 +249,8 @@ class DOPESHEET_GGT_SequenceGizmos(bpy.types.GizmoGroup):
         if not strip:
             return
 
-        frame_in = remap_frame_value(strip.frame_final_start, strip)
-        frame_out = remap_frame_value(strip.frame_final_end, strip)
+        frame_in = remap_frame_value(strip.left_handle, strip)
+        frame_out = remap_frame_value(strip.right_handle, strip)
         frame_in = region.view2d.view_to_region(frame_in, 0, clip=False)[0]
         frame_out = region.view2d.view_to_region(frame_out, 0, clip=False)[0]
 

--- a/spa_sequencer/sequence/props.py
+++ b/spa_sequencer/sequence/props.py
@@ -27,7 +27,7 @@ class SequenceSettings(bpy.types.PropertyGroup):
         """Set sequence active shot index."""
         # Move to beginning of shot strip in master scene.
         scene = get_sync_settings().master_scene
-        frame = scene.sequence_editor.strips[idx].frame_final_start
+        frame = scene.sequence_editor.strips[idx].left_handle
         scene.frame_set(frame)
 
     shot_active_index: bpy.props.IntProperty(

--- a/spa_sequencer/sequence/ui.py
+++ b/spa_sequencer/sequence/ui.py
@@ -107,7 +107,7 @@ class SEQUENCE_UL_shot(bpy.types.UIList):
         flt_neworder = []
 
         # Prepare data for sorting and perform sort
-        sort_data = [(idx, obj.frame_final_start) for idx, obj in enumerate(objects)]
+        sort_data = [(idx, obj.left_handle) for idx, obj in enumerate(objects)]
         flt_neworder = helper_funcs.sort_items_helper(sort_data, key=lambda obj: obj[1])
 
         return flt_flags, flt_neworder

--- a/spa_sequencer/shot/core.py
+++ b/spa_sequencer/shot/core.py
@@ -488,7 +488,7 @@ def reload_strip(strip: bpy.types.Strip):
 def adapt_scene_range(strip: bpy.types.SceneStrip):
     """Ensure `strip`'s internel range is fully contained in the scene its using."""
     # Update internal scene's end frame if exceeding the original one
-    new_frame_end = remap_frame_value(strip.frame_final_end - 1, strip)
+    new_frame_end = remap_frame_value(strip.right_handle - 1, strip)
     if new_frame_end <= strip.scene.frame_end:
         return
 
@@ -498,20 +498,20 @@ def adapt_scene_range(strip: bpy.types.SceneStrip):
 
 def adjust_shot_duration(
     strip: bpy.types.SceneStrip,
-    frame_offset: int,
+    handle_offset: int,
     from_frame_start: bool = False,
 ) -> bool:
     """
     Adjust the duration of `strip` and its underlying scene by offsetting either its end
-    or start frame (`from_frame_start` set to True) by `frame_offset`.
+    or start frame (`from_frame_start` set to True) by `handle_offset`.
     All strips on the same channel after `strip` are shifted accordingly.
 
-    Note that `frame_offset` is automatically clamped to:
+    Note that `handle_offset` is automatically clamped to:
     - ensure a minimum strip duration of 1
     - from frame start: stay in strip's scene range
 
     :param strip: The strip to adjust the duration of.
-    :param frame_offset: The frame offset to apply.
+    :param handle_offset: The frame offset to apply.
     :param from_frame_start: Whether to offset shot's inner start frame rather than its end frame.
     :return: Whether the function modified the duration of `strip`.
     """
@@ -519,21 +519,21 @@ def adjust_shot_duration(
         raise ValueError(f"Invalid shot: no scene set for '{strip.name}'")
 
     # Ensure the shot lasts at least 1 frame and compute effective offset
-    new_duration = max(strip.frame_final_duration + frame_offset, 1)
-    new_frame_offset = new_duration - strip.frame_final_duration
+    new_duration = max(strip.duration + handle_offset, 1)
+    new_handle_offset = new_duration - strip.duration
 
     # If adjusting from strip's frame start, clamp offset to never go beyond internal
     # scene's frame start.
     if from_frame_start:
         new_start_frame = max(
-            remap_frame_value(strip.frame_final_start, strip) - new_frame_offset,
+            remap_frame_value(strip.left_handle, strip) - new_handle_offset,
             strip.scene.frame_start,
         )
-        new_frame_offset = new_start_frame - remap_frame_value(
-            strip.frame_final_start, strip
+        new_handle_offset = new_start_frame - remap_frame_value(
+            strip.left_handle, strip
         )
 
-    if new_frame_offset == 0:
+    if new_handle_offset == 0:
         return False
 
     # Get sequence editor and scene from strip
@@ -545,10 +545,10 @@ def adjust_shot_duration(
         (
             s
             for s in sed.strips
-            if s.frame_final_start > strip.frame_final_start
+            if s.left_handle > strip.left_handle
             and s.channel == strip.channel
         ),
-        key=lambda s: s.frame_final_start,
+        key=lambda s: s.left_handle,
     )
     # Shift all impacted strips by offset.
     # Note: we adjust order of execution based on offset's sign to avoid
@@ -558,78 +558,78 @@ def adjust_shot_duration(
     #              strip's frame final start.
     if from_frame_start:
         # Positive offset: increase frame start => decrease strip duration
-        if new_frame_offset > 0:
+        if new_handle_offset > 0:
             # 1. Adjust strip values
-            strip.frame_offset_start += new_frame_offset
-            strip.frame_start -= new_frame_offset
+            strip.left_handle_offset += new_handle_offset
+            strip.content_start -= new_handle_offset
             # 2. Move impacted strips to the left
             for s in impacted_strips:
-                s.frame_start -= new_frame_offset
+                s.content_start -= new_handle_offset
         # Negative offset: decrease frame start => increase strip duration
         else:
             # 1. Move impacted strips to the right (reversed order)
             for s in reversed(impacted_strips):
-                s.frame_start -= new_frame_offset
+                s.content_start -= new_handle_offset
             # 2. Adjust strip values
-            strip.frame_start -= new_frame_offset
-            strip.frame_offset_start += new_frame_offset
+            strip.content_start -= new_handle_offset
+            strip.left_handle_offset += new_handle_offset
 
     # Frame end: shift scene and strip's final frame by offset.
     else:
         # Positive offset: increase frame end => increase duration
-        if new_frame_offset > 0:
+        if new_handle_offset > 0:
             # 1. Move impacted strips to the right (reversed order)
             for s in reversed(impacted_strips):
-                s.frame_start += new_frame_offset
+                s.content_start += new_handle_offset
             # 2. Adjust strip's duration
-            strip.frame_final_end += new_frame_offset
+            strip.right_handle += new_handle_offset
         # Negative offset: decrease frame end => decrease duration
         else:
             # 1. Adjust strip's duration
-            strip.frame_final_duration += new_frame_offset
+            strip.right_handle += new_handle_offset
             # 2. Move impacted strips to the left
             for s in impacted_strips:
-                s.frame_start += new_frame_offset
+                s.content_start += new_handle_offset
 
     adapt_scene_range(strip)
     return True
 
 
 def slip_shot_content(
-    strip: bpy.types.SceneStrip, frame_offset: int, clamp_start: bool = False
+    strip: bpy.types.SceneStrip, handle_offset: int, clamp_start: bool = False
 ):
     """
-    Slip `strip` content by `frame_offset`.
+    Slip `strip` content by `handle_offset`.
     A positive offset moves strip's internal range forwards.
 
     :param strip: The shot strip to consider.
-    :param frame_offset: The frame offset to apply.
+    :param handle_offset: The frame offset to apply.
     :param clamp_start: Whether to clamp to scene's frame start.
     """
     if clamp_start:
         # Clamp offset to never go beyond internal scene's frame start.
         new_start_frame = max(
-            remap_frame_value(strip.frame_final_start, strip) + frame_offset,
+            remap_frame_value(strip.left_handle, strip) + handle_offset,
             strip.scene.frame_start,
         )
 
-        new_frame_offset = new_start_frame - remap_frame_value(
-            strip.frame_final_start, strip
+        new_handle_offset = new_start_frame - remap_frame_value(
+            strip.left_handle, strip
         )
 
     else:
-        new_frame_offset = frame_offset
+        new_handle_offset = handle_offset
 
     # Store external values
-    frame_final_duration = strip.frame_final_duration
+    duration = strip.duration
     channel = strip.channel
     # Offset internal values to perform a content slip
-    strip.frame_offset_start += new_frame_offset
-    strip.frame_start -= new_frame_offset
-    strip.frame_offset_end -= new_frame_offset
+    strip.left_handle_offset += new_handle_offset
+    strip.content_start -= new_handle_offset
+    strip.right_handle_offset -= new_handle_offset
     # Ensure channel and duration are preserved
     strip.channel = channel
-    strip.frame_final_duration = frame_final_duration
+    set_shot_duration(strip, duration)
     adapt_scene_range(strip)
 
 
@@ -657,6 +657,13 @@ def get_scene_cameras(scene: bpy.types.Scene) -> list[bpy.types.Object]:
         key=lambda x: x.name,
     )
 
+
+def set_shot_duration(strip: bpy.types.Strip, duration:int):
+    """Set the Duration of a strip by adjusting it's handles
+      - [PR Comment](https://projects.blender.org/blender/blender/pulls/153012#issuecomment-1818253)
+      - [Release Notes](https://developer.blender.org/docs/release_notes/5.1/sequencer/#python-api)
+    """
+    strip.right_handle = strip.left_handle + duration
 
 def register():
     pass

--- a/spa_sequencer/shot/core.py
+++ b/spa_sequencer/shot/core.py
@@ -629,7 +629,7 @@ def slip_shot_content(
     strip.right_handle_offset -= new_handle_offset
     # Ensure channel and duration are preserved
     strip.channel = channel
-    set_shot_duration(strip, duration)
+    strip.duration = duration
     adapt_scene_range(strip)
 
 
@@ -657,13 +657,6 @@ def get_scene_cameras(scene: bpy.types.Scene) -> list[bpy.types.Object]:
         key=lambda x: x.name,
     )
 
-
-def set_shot_duration(strip: bpy.types.Strip, duration:int):
-    """Set the Duration of a strip by adjusting it's handles
-      - [PR Comment](https://projects.blender.org/blender/blender/pulls/153012#issuecomment-1818253)
-      - [Release Notes](https://developer.blender.org/docs/release_notes/5.1/sequencer/#python-api)
-    """
-    strip.right_handle = strip.left_handle + duration
 
 def register():
     pass

--- a/spa_sequencer/shot/ops.py
+++ b/spa_sequencer/shot/ops.py
@@ -12,7 +12,6 @@ from .core import (
     get_valid_shot_scenes,
     rename_scene,
     slip_shot_content,
-    set_shot_duration
 )
 from .naming import shot_naming, ShotNamingProperty
 from ..sync.core import (
@@ -290,7 +289,7 @@ class SEQUENCER_OT_shot_new(bpy.types.Operator):
             self.channel,
             edit_scene.frame_current,
         )
-        set_shot_duration(new_strip, self.duration)
+        new_strip.duration = self.duration
         slip_shot_content(new_strip, left_handle_offset)
         new_strip.scene_camera = new_strip.scene.camera
         edit_scene.sequence_editor.active_strip = new_strip
@@ -348,7 +347,7 @@ class SEQUENCER_OT_shot_duplicate(bpy.types.Operator):
             name, shot_scene, strip.channel, insert_frame
         )
 
-        set_shot_duration(new_strip, strip.duration)
+        new_strip.duration = strip.duration
 
         if not duplicate_scene:
             new_strip.scene_camera = strip.scene_camera

--- a/spa_sequencer/shot/ops.py
+++ b/spa_sequencer/shot/ops.py
@@ -12,6 +12,7 @@ from .core import (
     get_valid_shot_scenes,
     rename_scene,
     slip_shot_content,
+    set_shot_duration
 )
 from .naming import shot_naming, ShotNamingProperty
 from ..sync.core import (
@@ -26,7 +27,7 @@ def get_last_sequence(
     sequences: list[bpy.types.Strip],
 ) -> Optional[bpy.types.Strip]:
     """Get the last sequence, i.e. the one with the greatest final frame number."""
-    return max(sequences, key=lambda x: x.frame_final_end) if sequences else None
+    return max(sequences, key=lambda x: x.right_handle) if sequences else None
 
 
 def get_last_used_frame(
@@ -44,7 +45,7 @@ def get_last_used_frame(
     if not scene_sequences:
         return scene.frame_start - 1
 
-    return max(remap_frame_value(s.frame_final_end - 1, s) for s in scene_sequences)
+    return max(remap_frame_value(s.right_handle - 1, s) for s in scene_sequences)
 
 
 def get_selected_scene_sequences(
@@ -243,14 +244,14 @@ class SEQUENCER_OT_shot_new(bpy.types.Operator):
 
         edit_scene = get_edit_scene(context)
         sequences = edit_scene.sequence_editor.strips
-        frame_offset_start = 0
+        left_handle_offset = 0
 
         # Source scene handling.
         if self.scene_mode == "EXISTING":
             # Use existing scene as is.
             shot_scene = source_scene
             # Get the last frame used in the source scene to initialize the new strip.
-            frame_offset_start = self.start_3d - shot_scene.frame_start
+            left_handle_offset = self.start_3d - shot_scene.frame_start
         elif self.scene_mode == "NEW":
             # Create a new empty scene
             shot_scene = bpy.data.scenes.new(self.name)
@@ -273,7 +274,7 @@ class SEQUENCER_OT_shot_new(bpy.types.Operator):
             camera_obj.location = (0, -10, 2)
             camera_obj.rotation_euler = (1.5708, 0, 0)  # 90 degrees on X axis
             
-            frame_offset_start = 0  # No offset for a new scene
+            left_handle_offset = 0  # No offset for a new scene
         else:
             # Duplicate source scene.
             shot_scene = duplicate_scene(context, source_scene, self.name)
@@ -289,8 +290,8 @@ class SEQUENCER_OT_shot_new(bpy.types.Operator):
             self.channel,
             edit_scene.frame_current,
         )
-        new_strip.frame_final_duration = self.duration
-        slip_shot_content(new_strip, frame_offset_start)
+        set_shot_duration(new_strip, self.duration)
+        slip_shot_content(new_strip, left_handle_offset)
         new_strip.scene_camera = new_strip.scene.camera
         edit_scene.sequence_editor.active_strip = new_strip
 
@@ -298,11 +299,11 @@ class SEQUENCER_OT_shot_new(bpy.types.Operator):
             shot_scene.camera = source_scene.camera
 
         edit_scene.frame_end = max(
-            new_strip.frame_final_end - 1, edit_scene.frame_end
+            new_strip.right_handle - 1, edit_scene.frame_end
         )
 
         # Ensure newly created shot is visible.
-        ensure_sequencer_frame_visible(context, new_strip.frame_final_end)
+        ensure_sequencer_frame_visible(context, new_strip.right_handle)
 
         self.report({"INFO"}, f"Created new shot '{new_strip.name}'")
 
@@ -340,19 +341,19 @@ class SEQUENCER_OT_shot_duplicate(bpy.types.Operator):
             shot_scene = strip.scene
 
         # Find the frame where to insert the duplicated strip
-        insert_frame = get_last_sequence(sed.strips).frame_final_end
+        insert_frame = get_last_sequence(sed.strips).right_handle
 
         # Create new strip
         new_strip = sed.strips.new_scene(
             name, shot_scene, strip.channel, insert_frame
         )
 
-        new_strip.frame_final_duration = strip.frame_final_duration
+        set_shot_duration(new_strip, strip.duration)
 
         if not duplicate_scene:
             new_strip.scene_camera = strip.scene_camera
-            frame_offset = get_last_used_frame(sed.strips, shot_scene)
-            slip_shot_content(new_strip, frame_offset)
+            handle_offset = get_last_used_frame(sed.strips, shot_scene)
+            slip_shot_content(new_strip, handle_offset)
         else:
             new_strip.scene_camera = strip.scene.camera
 
@@ -372,7 +373,7 @@ class SEQUENCER_OT_shot_duplicate(bpy.types.Operator):
             return {"CANCELLED"}
 
         # Move current frame to the new strip's start frame.
-        edit_scene.frame_set(new_strips[0].frame_final_start)
+        edit_scene.frame_set(new_strips[0].left_handle)
 
         # Deselect all strips
         bpy.ops.sequencer.select_all(action="DESELECT")
@@ -385,11 +386,11 @@ class SEQUENCER_OT_shot_duplicate(bpy.types.Operator):
         edit_scene = get_edit_scene(context)
 
         edit_scene.frame_end = max(
-            new_strips[-1].frame_final_end - 1, edit_scene.frame_end
+            new_strips[-1].right_handle - 1, edit_scene.frame_end
         )
 
         # Ensure created strips are visible.
-        ensure_sequencer_frame_visible(context, new_strips[0].frame_final_end)
+        ensure_sequencer_frame_visible(context, new_strips[0].right_handle)
 
         self.report({"INFO"}, f"Duplicated {len(new_strips)} shot(s)")
 
@@ -544,9 +545,9 @@ class SEQUENCER_OT_shot_timing_adjust(bpy.types.Operator):
         if context.area.type == "SEQUENCE_EDITOR":
             self.strip_handle = "LEFT" if self.strip.select_left_handle else "RIGHT"
 
-        self.original_strip_duration = self.strip.frame_final_duration
+        self.original_strip_duration = self.strip.duration
         self.original_strip_scene_end = self.strip.scene.frame_end
-        self.original_strip_offset_start = self.strip.frame_offset_start
+        self.original_strip_offset_start = self.strip.left_handle_offset
         self.original_edit_frame_end = get_sync_settings().master_scene.frame_end
 
         context.window_manager.modal_handler_add(self)
@@ -555,7 +556,7 @@ class SEQUENCER_OT_shot_timing_adjust(bpy.types.Operator):
     def update_header_text(self, context, event):
         text = (
             f"Offset: {self.offset}"
-            f" | New Shot Duration: {self.strip.frame_final_duration}"
+            f" | New Shot Duration: {self.strip.duration}"
         )
         context.area.header_text_set(text)
 
@@ -602,10 +603,10 @@ class SEQUENCER_OT_shot_timing_adjust(bpy.types.Operator):
         offset = -self.offset if from_frame_start else self.offset
         # Compute current absolute offset from original duration
         if self.mode == "SLIP":
-            delta = self.strip.frame_offset_start - self.original_strip_offset_start
+            delta = self.strip.left_handle_offset - self.original_strip_offset_start
             slip_shot_content(self.strip, offset - delta, clamp_start=True)
         else:
-            delta = self.strip.frame_final_duration - self.original_strip_duration
+            delta = self.strip.duration - self.original_strip_duration
             adjust_shot_duration(self.strip, offset - delta, from_frame_start)
 
         edit_scene = get_sync_settings().master_scene
@@ -614,15 +615,15 @@ class SEQUENCER_OT_shot_timing_adjust(bpy.types.Operator):
             #       Set time to a non meaningful value before re-setting the correct frame
             #       value, to trigger time-dependent updates (e.g: synchronization).
             edit_scene.frame_set(-1)
-            update_frame = self.strip.frame_final_start
+            update_frame = self.strip.left_handle
         else:
-            update_frame = self.strip.frame_final_end - 1
+            update_frame = self.strip.right_handle - 1
 
         # Set sequencer's frame to strip's new end frame
         edit_scene.frame_set(update_frame)
 
         # Update both edit and internal scene's end frame if going past original ones
-        frame_end = self.strip.frame_final_end - 1
+        frame_end = self.strip.right_handle - 1
         edit_scene.frame_end = max(frame_end, self.original_edit_frame_end)
         self.strip.scene.frame_end = max(
             remap_frame_value(frame_end, self.strip),
@@ -812,7 +813,7 @@ class SEQUENCER_OT_shot_chronological_numbering(bpy.types.Operator):
         items_to_rename: dict[bpy.types.SceneStrip, tuple[str, bool]] = dict()
 
         # Go through the shots chronologically (sorted by the start frame)
-        sorted_scene_strips = sorted(scene_strips, key=lambda x: x.frame_final_start)
+        sorted_scene_strips = sorted(scene_strips, key=lambda x: x.left_handle)
 
         # 1st pass: list items (strips/scenes) to rename.
         for strip in sorted_scene_strips:

--- a/spa_sequencer/sync/core.py
+++ b/spa_sequencer/sync/core.py
@@ -167,7 +167,7 @@ def remap_frame_value(frame: int, scene_strip: bpy.types.SceneStrip) -> int:
     :param scene_strip: The scene strip to remap to.
     :returns: The remapped frame value
     """
-    return int(frame - scene_strip.frame_start + scene_strip.scene.frame_start)
+    return int(frame - scene_strip.content_start + scene_strip.scene.frame_start)
 
 
 def get_strips_at_frame(
@@ -191,7 +191,7 @@ def get_strips_at_frame(
         if (
             (not type_filter or isinstance(s, type_filter))
             and (not skip_muted or not s.mute)
-            and (frame >= s.frame_final_start and frame < s.frame_final_end)
+            and (frame >= s.left_handle and frame < s.right_handle)
         )
     ]
 
@@ -400,8 +400,8 @@ def update_preview_range(scene_strip: bpy.types.SceneStrip):
         scene_strip.scene.use_preview_range = True
 
     # Compute and update preview range if necessary
-    start = remap_frame_value(scene_strip.frame_final_start, scene_strip)
-    end = remap_frame_value(scene_strip.frame_final_end, scene_strip) - 1
+    start = remap_frame_value(scene_strip.left_handle, scene_strip)
+    end = remap_frame_value(scene_strip.right_handle, scene_strip) - 1
     if start != scene_strip.scene.frame_preview_start:
         scene_strip.scene.frame_preview_start = start
     if end != scene_strip.scene.frame_preview_end:
@@ -486,12 +486,12 @@ def sync_system_update(context: bpy.types.Context, force: bool = False):
                 return
 
             # Compute strip range in scene's referential
-            frame_start = remap_frame_value(strip.frame_final_start, strip)
-            frame_end = remap_frame_value(strip.frame_final_end - 1, strip)
+            frame_start = remap_frame_value(strip.left_handle, strip)
+            frame_end = remap_frame_value(strip.right_handle - 1, strip)
 
             # Compute new strip range in current strip referential
-            new_strip_start = remap_frame_value(new_strip.frame_final_start, strip)
-            new_strip_end = remap_frame_value(new_strip.frame_final_end - 1, strip)
+            new_strip_start = remap_frame_value(new_strip.left_handle, strip)
+            new_strip_end = remap_frame_value(new_strip.right_handle - 1, strip)
 
             # If current frame is not consecutive to current strip boundary
             # or equal to one of the new strip's boundary,

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -9,6 +9,7 @@ from pytest import fixture
 
 from utils import create_shot_scene
 from spa_sequencer.render.props import BLENDER_EEVEE
+from spa_sequencer.shot.core import set_shot_duration
 
 
 @fixture
@@ -34,7 +35,7 @@ def basic_render_setup() -> tuple[bpy.types.Scene, bpy.types.SceneStrip]:
         shot_scene.camera = bpy.context.active_object
 
     # Set shot strip duration to just 1 frame for fast testing
-    shot_strip.frame_final_duration = 1
+    set_shot_duration(shot_strip, 1)
 
     # Switch back to edit scene
     bpy.context.window.scene = edit_scene

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -9,7 +9,6 @@ from pytest import fixture
 
 from utils import create_shot_scene
 from spa_sequencer.render.props import BLENDER_EEVEE
-from spa_sequencer.shot.core import set_shot_duration
 
 
 @fixture
@@ -35,7 +34,7 @@ def basic_render_setup() -> tuple[bpy.types.Scene, bpy.types.SceneStrip]:
         shot_scene.camera = bpy.context.active_object
 
     # Set shot strip duration to just 1 frame for fast testing
-    set_shot_duration(shot_strip, 1)
+    shot_strip.duration = 1
 
     # Switch back to edit scene
     bpy.context.window.scene = edit_scene

--- a/tests/test_shot.py
+++ b/tests/test_shot.py
@@ -266,15 +266,15 @@ def test_scene_delete_scene_duplicate_with_shared_collection():
 def test_shot_duration_adjust_positive_offset():
     # Create a shot
     sh1 = create_shot_scene(bpy.context.scene, 1, 1)
-    sh1_original_duration = sh1.frame_final_duration
+    sh1_original_duration = sh1.duration
 
     # Adjust duration: use a positive offset
     offset = 10
     adjust_shot_duration(sh1, offset)
 
     # Strip's final duration and internal scene range should have been impacted
-    assert sh1.frame_final_duration == sh1_original_duration + offset
-    assert sh1.scene.frame_end == sh1.scene.frame_start + sh1.frame_final_duration - 1
+    assert sh1.duration == sh1_original_duration + offset
+    assert sh1.scene.frame_end == sh1.scene.frame_start + sh1.duration - 1
 
 
 def test_shot_duration_adjust_negative_offset():
@@ -284,11 +284,11 @@ def test_shot_duration_adjust_negative_offset():
 
     # Adjust duration: use a negative offset
     sh1_new_duration = 10
-    offset = sh1_new_duration - sh1.frame_final_duration
+    offset = sh1_new_duration - sh1.duration
     adjust_shot_duration(sh1, offset)
 
     # Strip's final duration should have been impacted
-    assert sh1.frame_final_duration == sh1_new_duration
+    assert sh1.duration == sh1_new_duration
     # Internal scene range should have been preserved (shorter duration)
     assert sh1.scene.frame_end == original_frame_end
 
@@ -300,11 +300,11 @@ def test_shot_duration_adjust_negative_offset_clamp():
 
     # Adjust duration: use a negative offset leading to a null duration
     sh1_new_duration = 0
-    offset = sh1_new_duration - sh1.frame_final_duration
+    offset = sh1_new_duration - sh1.duration
     adjust_shot_duration(sh1, offset)
 
     # Duration should have been clamped to 1
-    assert sh1.frame_final_duration == 1
+    assert sh1.duration == 1
     # Internal scene range should have been preserved (shorter duration)
     assert sh1.scene.frame_end == original_frame_end
 
@@ -313,69 +313,69 @@ def test_shot_duration_adjust_from_start_negative_offset():
     # Create a shot
     sh1 = create_shot_scene(bpy.context.scene, 1, 1)
 
-    duration = sh1.frame_final_duration
+    duration = sh1.duration
     # Adjust duration from frame start
     offset = -10
     adjust_shot_duration(sh1, offset, from_frame_start=True)
 
     # Strip start frame should not have changed
-    assert sh1.frame_final_start == 1
+    assert sh1.left_handle == 1
     # Strip content should have been offset
-    assert sh1.frame_offset_start == -offset
-    assert sh1.frame_final_duration == duration + offset
+    assert sh1.left_handle_offset == -offset
+    assert sh1.duration == duration + offset
 
 
 def test_shot_duration_adjust_from_start_negative_offset_clamp():
     # Create a shot
     sh1 = create_shot_scene(bpy.context.scene, 1, 1)
 
-    duration = sh1.frame_final_duration
+    duration = sh1.duration
     # Adjust duration from frame start with an offset going above frame end
     offset = -duration * 2
     adjust_shot_duration(sh1, offset, from_frame_start=True)
 
     # Strip start frame should not have changed
-    assert sh1.frame_final_start == 1
+    assert sh1.left_handle == 1
     # Strip content offset should have been clamped to have a minimum duration of 1
-    assert sh1.frame_offset_start == duration - 1
-    assert sh1.frame_final_duration == 1
+    assert sh1.left_handle_offset == duration - 1
+    assert sh1.duration == 1
 
 
 def test_shot_duration_adjust_from_start_positive_offset_clamp():
     # Create a shot
     sh1 = create_shot_scene(bpy.context.scene, 1, 1)
 
-    duration = sh1.frame_final_duration
+    duration = sh1.duration
     # Adjust duration from frame start with a positive offset going above strip's
     # scene frame start.
     offset = 1
     adjust_shot_duration(sh1, offset, from_frame_start=True)
 
     # Strip start frame should not have changed
-    assert sh1.frame_final_start == 1
+    assert sh1.left_handle == 1
     # Offset should have been clamped to stay in scene's range
-    assert sh1.frame_offset_start == 0
+    assert sh1.left_handle_offset == 0
     # Duration should not have changed
-    assert sh1.frame_final_duration == duration
+    assert sh1.duration == duration
 
 
 def test_shot_duration_adjust_with_multiple_shots():
     # Create a sequence with 3 shots following each others
     sh1 = create_shot_scene(bpy.context.scene, 1, bpy.context.scene.frame_start)
-    sh2 = create_shot_scene(bpy.context.scene, 1, sh1.frame_final_end)
-    sh3 = create_shot_scene(bpy.context.scene, 1, sh2.frame_final_end)
+    sh2 = create_shot_scene(bpy.context.scene, 1, sh1.right_handle)
+    sh3 = create_shot_scene(bpy.context.scene, 1, sh2.right_handle)
 
     # Retime the shot in between
-    sh2_original_frame_end = sh2.frame_final_end
+    sh2_original_frame_end = sh2.right_handle
     offset = 10
     adjust_shot_duration(sh2, offset)
 
     # 1st shot should not have been impacted
-    assert sh1.frame_final_start == bpy.context.scene.frame_start
+    assert sh1.left_handle == bpy.context.scene.frame_start
     # 2nd shot's duration should have changed
-    assert sh2.frame_final_end == sh2_original_frame_end + offset
+    assert sh2.right_handle == sh2_original_frame_end + offset
     # 3rd shot should have been shifted
-    assert sh3.frame_final_start == sh2.frame_final_end
+    assert sh3.left_handle == sh2.right_handle
 
 
 def test_shot_slip_content_positive_offset():
@@ -388,9 +388,9 @@ def test_shot_slip_content_positive_offset():
     slip_shot_content(sh2, offset)
 
     # Ensure strip frame_start members were propertly updated
-    assert sh2.frame_offset_start == sh1.frame_offset_start + offset
-    assert sh2.frame_start == sh1.frame_start - offset
-    assert sh2.frame_final_start == sh1.frame_final_start
+    assert sh2.left_handle_offset == sh1.left_handle_offset + offset
+    assert sh2.content_start == sh1.content_start - offset
+    assert sh2.left_handle == sh1.left_handle
 
 
 def test_shot_slip_content_negative_offset():
@@ -404,12 +404,12 @@ def test_shot_slip_content_negative_offset():
     # Strip's internal range start at internal frame start.
     # With clamp_start enabled, this sould not change anything.
     slip_shot_content(sh2, offset, clamp_start=True)
-    assert sh2.frame_offset_start == sh1.frame_offset_start
-    assert sh2.frame_start == sh1.frame_start
-    assert sh2.frame_final_start == sh1.frame_final_start
+    assert sh2.left_handle_offset == sh1.left_handle_offset
+    assert sh2.content_start == sh1.content_start
+    assert sh2.left_handle == sh1.left_handle
 
     # Without clamp, offset should have been applied
     slip_shot_content(sh2, offset, clamp_start=False)
-    assert sh2.frame_offset_start == sh1.frame_offset_start + offset
-    assert sh2.frame_start == sh1.frame_start - offset
-    assert sh2.frame_final_start == sh1.frame_final_start
+    assert sh2.left_handle_offset == sh1.left_handle_offset + offset
+    assert sh2.content_start == sh1.content_start - offset
+    assert sh2.left_handle == sh1.left_handle

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -6,7 +6,6 @@ import bpy
 from pytest import fixture
 
 from spa_sequencer.sync.core import remap_frame_value, get_sync_settings, set_grease_pencil_brush
-from spa_sequencer.shot.core import set_shot_duration
 
 from utils import create_shot_scene
 
@@ -56,7 +55,7 @@ def test_change_edit_time(basic_synced_setup):
     edit_scene, shot_strip = basic_synced_setup
 
     # Shorten the strip length
-    set_shot_duration(shot_strip, 10)
+    shot_strip.duration = 10
 
     # Change edit scene's frame within shot's boundaries
     edit_frame = 4

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -6,6 +6,7 @@ import bpy
 from pytest import fixture
 
 from spa_sequencer.sync.core import remap_frame_value, get_sync_settings, set_grease_pencil_brush
+from spa_sequencer.shot.core import set_shot_duration
 
 from utils import create_shot_scene
 
@@ -44,9 +45,9 @@ def complex_synced_setup(
     """
     edit_scene, shot_strip = basic_synced_setup
     shot_strip_1 = shot_strip
-    shot_strip_2 = create_shot_scene(edit_scene, 2, shot_strip.frame_final_start)
-    shot_strip_3 = create_shot_scene(edit_scene, 3, shot_strip.frame_final_start)
-    shot_strip_4 = create_shot_scene(edit_scene, 4, shot_strip.frame_final_start)
+    shot_strip_2 = create_shot_scene(edit_scene, 2, shot_strip.left_handle)
+    shot_strip_3 = create_shot_scene(edit_scene, 3, shot_strip.left_handle)
+    shot_strip_4 = create_shot_scene(edit_scene, 4, shot_strip.left_handle)
 
     return (edit_scene, [shot_strip_1, shot_strip_2, shot_strip_3, shot_strip_4])
 
@@ -55,7 +56,7 @@ def test_change_edit_time(basic_synced_setup):
     edit_scene, shot_strip = basic_synced_setup
 
     # Shorten the strip length
-    shot_strip.frame_final_duration = 10
+    set_shot_duration(shot_strip, 10)
 
     # Change edit scene's frame within shot's boundaries
     edit_frame = 4
@@ -106,7 +107,7 @@ def test_window_scene_sync(basic_synced_setup):
     edit_scene, shot_strip_1 = basic_synced_setup
 
     # Create a 2nd shot after the first one
-    create_shot_scene(edit_scene, 1, shot_strip_1.frame_final_end)
+    create_shot_scene(edit_scene, 1, shot_strip_1.right_handle)
 
     # Start the tests from a neutral scene
     bpy.context.window.scene = edit_scene
@@ -115,7 +116,7 @@ def test_window_scene_sync(basic_synced_setup):
     # Moving the edit frame to the start of each strip should
     # update window's scene accordingly.
     for strip in edit_scene.sequence_editor.strips:
-        edit_scene.frame_set(strip.frame_final_start)
+        edit_scene.frame_set(strip.left_handle)
         assert bpy.context.window.scene == strip.scene
 
 
@@ -138,7 +139,7 @@ def test_keep_gp_toolsettings(basic_synced_setup):
 
     # Shot 2
     # Create a GP object and assign the same materials as the first one
-    shot_strip_2 = create_shot_scene(edit_scene, 1, shot_strip_1.frame_final_end)
+    shot_strip_2 = create_shot_scene(edit_scene, 1, shot_strip_1.right_handle)
     bpy.context.window.scene = shot_strip_2.scene
     bpy.ops.object.grease_pencil_add(type="MONKEY")
     bpy.ops.object.mode_set(mode="PAINT_GREASE_PENCIL")
@@ -151,7 +152,7 @@ def test_keep_gp_toolsettings(basic_synced_setup):
 
     # Shot 3
     # Empty scene
-    shot_strip_3 = create_shot_scene(edit_scene, 1, shot_strip_2.frame_final_end)
+    shot_strip_3 = create_shot_scene(edit_scene, 1, shot_strip_2.right_handle)
     gp_settings_3 = shot_strip_3.scene.tool_settings.gpencil_paint
 
     # Start the tests from a neutral scene
@@ -159,14 +160,14 @@ def test_keep_gp_toolsettings(basic_synced_setup):
     edit_scene.frame_set(0)
 
     # Go to Shot 1 and change the active object's material
-    edit_scene.frame_set(shot_strip_1.frame_final_start)
+    edit_scene.frame_set(shot_strip_1.left_handle)
     gpencil_shot_1.active_material_index = 2
 
     # Go to Shot2
-    edit_scene.frame_set(shot_strip_2.frame_final_start)
+    edit_scene.frame_set(shot_strip_2.left_handle)
 
     # Go to Shot3
-    edit_scene.frame_set(shot_strip_3.frame_final_start)
+    edit_scene.frame_set(shot_strip_3.left_handle)
 
     # Check that grease pencil settings are identical for Shot 1 and 2
     assert gp_settings_2.brush == gp_settings_1.brush
@@ -192,11 +193,11 @@ def test_keep_gp_toolsettings_interaction_mode(basic_synced_setup):
 
     # Shot 2
     # Empty scene
-    shot_strip_2 = create_shot_scene(edit_scene, 1, shot_strip_1.frame_final_end)
+    shot_strip_2 = create_shot_scene(edit_scene, 1, shot_strip_1.right_handle)
 
     # Shot 3
     # Scene with a single GP object
-    shot_strip_3 = create_shot_scene(edit_scene, 1, shot_strip_2.frame_final_end)
+    shot_strip_3 = create_shot_scene(edit_scene, 1, shot_strip_2.right_handle)
     bpy.context.window.scene = shot_strip_3.scene
     bpy.ops.object.grease_pencil_add(type="MONKEY")
     gpencil_shot_3 = bpy.context.active_object
@@ -206,11 +207,11 @@ def test_keep_gp_toolsettings_interaction_mode(basic_synced_setup):
     edit_scene.frame_set(0)
 
     # Go to Shot 1: active GP object in paint mode
-    edit_scene.frame_set(shot_strip_1.frame_final_start)
+    edit_scene.frame_set(shot_strip_1.left_handle)
     # Go to Shot 2: no active object
-    edit_scene.frame_set(shot_strip_2.frame_final_start)
+    edit_scene.frame_set(shot_strip_2.left_handle)
     # Go to Shot 3: active GP object initially in object mode
-    edit_scene.frame_set(shot_strip_3.frame_final_start)
+    edit_scene.frame_set(shot_strip_3.left_handle)
     # Ensure GP mode was applied to the one in Shot 3, despite Shot 2 being empty
     assert gpencil_shot_1.mode == gpencil_shot_3.mode == interaction_mode
 
@@ -218,28 +219,28 @@ def test_keep_gp_toolsettings_interaction_mode(basic_synced_setup):
 def test_bidirectional_within_shot_range(basic_synced_setup):
     edit_scene, shot_strip_1 = basic_synced_setup
 
-    edit_scene.frame_set(shot_strip_1.frame_final_start)
+    edit_scene.frame_set(shot_strip_1.left_handle)
     assert bpy.context.window.scene == shot_strip_1.scene
     offset = 1
     shot_strip_1.scene.frame_set(shot_strip_1.scene.frame_current + offset)
-    assert edit_scene.frame_current == shot_strip_1.frame_final_start + offset
+    assert edit_scene.frame_current == shot_strip_1.left_handle + offset
 
 
 def test_bidirectional_outside_shot_range(basic_synced_setup):
     edit_scene, shot_strip_1 = basic_synced_setup
-    edit_scene.frame_set(shot_strip_1.frame_final_start)
+    edit_scene.frame_set(shot_strip_1.left_handle)
 
     # Go outside scene's range
     shot_strip_1.scene.frame_set(shot_strip_1.scene.frame_end + 10)
     # Master time should not have been updated
-    assert edit_scene.frame_current == shot_strip_1.frame_final_start
+    assert edit_scene.frame_current == shot_strip_1.left_handle
 
 
 def test_bidirectional_outside_shot_range_to_surrounding_shots(basic_synced_setup):
     edit_scene, shot_strip_1 = basic_synced_setup
-    edit_scene.frame_set(shot_strip_1.frame_final_start)
+    edit_scene.frame_set(shot_strip_1.left_handle)
     # Create another Shot right after Shot 1
-    shot_strip_2 = create_shot_scene(edit_scene, 1, shot_strip_1.frame_final_end)
+    shot_strip_2 = create_shot_scene(edit_scene, 1, shot_strip_1.right_handle)
 
     # From frame start, go outside scene's range within Shot 1 by one frame
     shot_strip_1.scene.frame_set(shot_strip_1.scene.frame_end + 1)
@@ -250,13 +251,13 @@ def test_bidirectional_outside_shot_range_to_surrounding_shots(basic_synced_setu
     # Go outside scene's range within Shot 1 by one frame
     shot_strip_1.scene.frame_set(shot_strip_1.scene.frame_end + 1)
     # Master time should have been update and Shot 2 should now be the active Shot
-    assert edit_scene.frame_current == shot_strip_2.frame_final_start
+    assert edit_scene.frame_current == shot_strip_2.left_handle
     assert bpy.context.window.scene == shot_strip_2.scene
 
     # Go back one frame before Shot 2 frame start
     shot_strip_2.scene.frame_set(shot_strip_2.scene.frame_start - 1)
     # Master time should have been updated and Shot 1 should not be active again
-    assert edit_scene.frame_current == shot_strip_1.frame_final_end - 1
+    assert edit_scene.frame_current == shot_strip_1.right_handle - 1
     assert bpy.context.window.scene == shot_strip_1.scene
 
 
@@ -265,9 +266,9 @@ def test_bidirectional_off(basic_synced_setup):
     sync_settings = get_sync_settings()
     sync_settings.bidirectional = False
 
-    edit_scene.frame_set(shot_strip_1.frame_final_start)
+    edit_scene.frame_set(shot_strip_1.left_handle)
     shot_strip_1.scene.frame_set(shot_strip_1.scene.frame_current + 10)
-    assert edit_scene.frame_current == shot_strip_1.frame_final_start
+    assert edit_scene.frame_current == shot_strip_1.left_handle
 
 
 def test_camera_strip(basic_synced_setup):
@@ -287,7 +288,7 @@ def test_camera_strip(basic_synced_setup):
         name=f"{shot_scene.name}_2",
         scene=shot_scene,
         channel=1,
-        frame_start=shot_strip_1.frame_final_end,
+        frame_start=shot_strip_1.right_handle,
     )
 
     # Define different cameras for each strip
@@ -295,10 +296,10 @@ def test_camera_strip(basic_synced_setup):
     shot_strip_2.scene_camera = cam2
 
     # Go to 1st strip: the scene should be using cam1 as active camera
-    edit_scene.frame_set(shot_strip_1.frame_final_start)
+    edit_scene.frame_set(shot_strip_1.left_handle)
     assert shot_scene.camera == shot_strip_1.scene_camera == cam1
     # Go to 2n strip: the scene should be using cam1 as active camera
-    edit_scene.frame_set(shot_strip_2.frame_final_start)
+    edit_scene.frame_set(shot_strip_2.left_handle)
     assert shot_scene.camera == shot_strip_2.scene_camera == cam2
 
 
@@ -328,7 +329,7 @@ def test_active_follows_playhead(basic_synced_setup):
     sync_settings = get_sync_settings()
     sync_settings.active_follows_playhead = True
 
-    shot_strip_2 = create_shot_scene(edit_scene, 1, shot_strip_1.frame_final_end + 1)
+    shot_strip_2 = create_shot_scene(edit_scene, 1, shot_strip_1.right_handle + 1)
 
-    edit_scene.frame_set(shot_strip_2.frame_final_start)
+    edit_scene.frame_set(shot_strip_2.left_handle)
     assert edit_scene.sequence_editor.active_strip == shot_strip_2


### PR DESCRIPTION
 - Release Notes on API Changes: https://developer.blender.org/docs/release_notes/5.1/sequencer/#python-api

 - PR Introduces API Changes: https://projects.blender.org/blender/blender/pulls/153012#:~:text=So%20I%27ve%20made%20Strip%20Duration%20read%2Donly

 - What use to be called `frame_offset` in the codebase is now being renamed to `handle_offset` for better alignment with the updated API

 - Duration acts the same as it use to.  https://projects.blender.org/blender/blender/commit/ada6f2bd4111f95d6989c7720e3564700a72abc7 change made between 5.1.0 and 5.1.1 this means there will be issues running this with Blender 5.1.0
 
 TODO:  
 - [x] Use editable duration property see