### PR TITLE
Fix: Remove Shot Prefix from Conform Shots Operator

### DIFF
--- a/docs/editorial.md
+++ b/docs/editorial.md
@@ -41,7 +41,6 @@ Conform existing scene strips to the timing from a previously imported timeline.
 
 - **Reference Channel:** The channel containing the imported timeline to use as conformation reference.
 - **Target Channel:** The channel containing scene strips to apply the conformation to.
-- **Shot Prefix:** Prefix to use on newly created shots. 
 - **Shot ID Regex:** Naming pattern to extract shot name from Scene Strips.
 - **Freeze Frame Handles:** The duration of the handles found on the input media.
     - **Applied to Metadata:** Extend Scene Strip's internal range by the indicated Freeze Frame handles  (only using freeze frame handles). 

--- a/spa_sequencer/editorial/ops.py
+++ b/spa_sequencer/editorial/ops.py
@@ -152,12 +152,6 @@ class SEQUENCER_OT_edit_conform_shots_from_editorial(bpy.types.Operator):
         default=2,
     )
 
-    shot_prefix: bpy.props.EnumProperty(
-        name="Shot Prefix",
-        description="Shot prefix",
-        items=get_shot_prefix_enum,
-    )
-
     shot_id_regex: bpy.props.StringProperty(
         name="Shot ID Regex",
         description="Single capture group regex to extract shot id from panel names",
@@ -192,7 +186,6 @@ class SEQUENCER_OT_edit_conform_shots_from_editorial(bpy.types.Operator):
         self.layout.use_property_split = True
         self.layout.prop(self, "ref_channel")
         self.layout.prop(self, "target_channel")
-        self.layout.prop(self, "shot_prefix")
         self.layout.prop(self, "shot_id_regex")
         box = self.layout.box()
         box.prop(self, "freeze_frame_handles", expand=True)


### PR DESCRIPTION
Closes: https://github.com/NickTiny/SPArk-sequencer-addon/issues/59

Remove unused operator property from `SEQUENCER_OT_edit_conform_shots_from_editorial` operator and documentation.