### PR TITLE
Fix: Exception if No Scene Camera is Found

### DIFF
--- a/spa_sequencer/sequence/ui.py
+++ b/spa_sequencer/sequence/ui.py
@@ -144,7 +144,9 @@ class VIEW3D_PT_sequence(bpy.types.Panel):
         # Draw shot lists in the master sequence.
         self.draw_shots_list(context, master_scene.sequence_editor)
         # Draw active shot details if any.
-        if strip := get_sync_master_strip(use_cache=True)[0]:
+        if (
+            strip := get_sync_master_strip(use_cache=True)[0]
+        ) and strip.scene == context.scene:
             self.draw_shot_strip(context, strip)
 
     def draw_shots_list(self, context, sed):

--- a/spa_sequencer/sequence/ui.py
+++ b/spa_sequencer/sequence/ui.py
@@ -143,7 +143,7 @@ class VIEW3D_PT_sequence(bpy.types.Panel):
 
         # Draw shot lists in the master sequence.
         self.draw_shots_list(context, master_scene.sequence_editor)
-        # Draw active shot details if any.
+        # Draw available active shot details if window scene is strip scene.
         if (
             strip := get_sync_master_strip(use_cache=True)[0]
         ) and strip.scene == context.scene:
@@ -210,7 +210,7 @@ class VIEW3D_PT_sequence(bpy.types.Panel):
                 text="",
             )
             props.camera = context.scene.camera.name
-        
+
         # FIXME : Don't know what this unkown ops is suppose que to do
         # row = col.row()
         # row.operator("scene.camera_select", icon="RESTRICT_SELECT_OFF", text="Select")


### PR DESCRIPTION
Closes: https://github.com/NickTiny/SPArk-sequencer-addon/issues/71

When no scene camera exists for this scene (e.g. output scene), evaluating the line `f"Active ({context.scene.camera.name})"` in `draw_shot_strip()` will raise an exception.

The best fix here is to actually skip drawing the entire `draw_shot_strip()` section, if the window scene is not the strip scene.

If the window scene is not the strip scene, then we do not want to display menus to modify that strip, until the scene is displayed.

<img width="631" height="583" alt="image" src="https://github.com/user-attachments/assets/81afa390-9a8e-4d3d-94e7-68e51286f8eb" />
