### PR TITLE
Feature: Scene Asset Integration

### DIFF
--- a/docs/shot.md
+++ b/docs/shot.md
@@ -17,10 +17,12 @@ The SPArk Sequencer Shot Menu offers unique controls that differ from Blender's 
 To add a shot select **Shot > New** from the **Sequencer** Header Menu. **Use Existing** will copy the Scene from the active strip. When a Metastrip is open in the Sequencer, the new shot will be placed inside it.
 
 - **Shot Name:** Set a Prefix/Number/Take: Use arrow to get the next available shot name.
-- **Scene:** Use existing (most cases) or create a new scene from a Template.
+- **Scene:** Defines how target scene is created/set. Modes include; "Blank", "New from Asset" or "Use Existing".
 - **Source:** Available scenes + templates (set in add-on preferences).
 - **Duration:** Set the duration in frames.
 - **Channel:** Select a row (aka channel) to place this new clip on, in the Sequencer.
+
+**Note**: For Asset scenes, only local scene assets are considered. To create strips from a Scene in the Asset Library, append it into your scene first.
 
 ### Duplicate Shot
 When Duplicating a shot, the selected contents are appended to the end of your timeline, this also means that these clips are shifted in the Dope Sheet. To duplicate a shot without adjusting its timing use Blender's native [Strip Duplicate Operator](https://docs.blender.org/manual/en/latest/video_editing/edit/montage/editing.html#duplicate). When a Metastrip is open in the Sequencer, the duplicated shot will be placed inside it.

--- a/spa_sequencer/preferences.py
+++ b/spa_sequencer/preferences.py
@@ -12,16 +12,7 @@ from .utils import register_classes, unregister_classes
 
 class SPASequencerAddonPreferences(bpy.types.AddonPreferences):
     bl_idname = __package__
-
-    shot_template_prefix: bpy.props.StringProperty(
-        name="Shot Template Prefix",
-        description="Scene name prefix that identifies Shot Templates",
-        default="TEMPLATE_SHOT",
-    )
-
-    def draw(self, context):
-        self.layout.prop(self, "shot_template_prefix")
-
+    # Empty for now but may be useful for future features
 
 def get_addon_prefs() -> SPASequencerAddonPreferences:
     """Get the Addon Preferences instance."""

--- a/spa_sequencer/shot/core.py
+++ b/spa_sequencer/shot/core.py
@@ -649,7 +649,7 @@ def get_valid_shot_scenes() -> list[bpy.types.Scene]:
         for scene in bpy.data.scenes
         if (
             # Discard template scenes.
-            not scene.name.startswith(prefs.shot_template_prefix)
+            not scene.asset_data is not None
             # Discard master sync scene.
             and scene != get_sync_settings().master_scene
             # Discard empty scenes.
@@ -784,4 +784,3 @@ def register():
 def unregister():
     del bpy.types.Strip.audition
     unregister_classes(classes)
-

--- a/spa_sequencer/shot/ops.py
+++ b/spa_sequencer/shot/ops.py
@@ -92,8 +92,6 @@ class SEQUENCER_OT_shot_new(bpy.types.Operator):
 
     def get_template_scenes(self, context):
         """Get the scenes matching template naming rule defined in preferences."""
-        prefs = get_addon_prefs()
-        prefix = prefs.shot_template_prefix
 
         shot_scenes = get_valid_shot_scenes()
 
@@ -104,7 +102,7 @@ class SEQUENCER_OT_shot_new(bpy.types.Operator):
                     return scene in shot_scenes
                 case "TEMPLATE":
                     # Only show template scenes in this case.
-                    return scene.name.startswith(prefix)
+                    return scene.asset_data is not None
                 case "NEW":
                     # No need for source scene in NEW mode
                     return False
@@ -131,8 +129,8 @@ class SEQUENCER_OT_shot_new(bpy.types.Operator):
         description="Shot creation mode",
         items=(
             ("EXISTING", "Use Existing", "Use existing scene"),
-            ("TEMPLATE", "New From Template", "Create a new scene from a template"),
-            ("NEW", "New", "Create a new empty scene"),
+            ("TEMPLATE", "New From Asset", "New scene from a scene 'template' asset"),
+            ("NEW", "Blank", "Create a new empty scene"),
         ),
         default="EXISTING",
         update=update_default_source_scene,
@@ -185,7 +183,7 @@ class SEQUENCER_OT_shot_new(bpy.types.Operator):
 
     def invoke(self, context: bpy.types.Context, _event):
         edit_scene = get_edit_scene(context)
-        
+
         if not (sed := edit_scene.sequence_editor):
             self.name = shot_naming.default_shot_name()
         else:
@@ -258,11 +256,11 @@ class SEQUENCER_OT_shot_new(bpy.types.Operator):
         elif self.scene_mode == "NEW":
             # Create a new empty scene
             shot_scene = bpy.data.scenes.new(self.name)
-            
+
             # Set scene's frame range
             shot_scene.frame_start = 1
             shot_scene.frame_end = shot_scene.frame_start + self.duration - 1
-            
+
             # Create a camera for the new scene
             for i in range(1, 100000):
                 camera_name = f"Camera_{i:03d}"
@@ -272,11 +270,11 @@ class SEQUENCER_OT_shot_new(bpy.types.Operator):
             camera_obj = bpy.data.objects.new(name=camera_name, object_data=camera_data)
             shot_scene.collection.objects.link(camera_obj)
             shot_scene.camera = camera_obj
-            
+
             # Set a position for new camera
             camera_obj.location = (0, -10, 2)
             camera_obj.rotation_euler = (1.5708, 0, 0)  # 90 degrees on X axis
-            
+
             left_handle_offset = 0  # No offset for a new scene
         else:
             # Duplicate source scene.


### PR DESCRIPTION
Closes: https://github.com/NickTiny/SPArk-sequencer-addon/issues/67

Closes: https://github.com/NickTiny/SPArk-sequencer-addon/issues/21

The goal of this PR is to streamline the use of templates. The pre-existing template system is being replaced with Assets for closer alignment with Blender's native design.

This is an improvement because it doesn't require prefixes which are brittle and have some confusion for users (e.g. https://github.com/NickTiny/SPArk-sequencer-addon/issues/21)

**Note**: Only local Scene Assets are supported (noted in the documentation.

## Changes
 - Remove Template Scene Feature
 - Use Scene Assets in the New Scene Operator
 - Update Documentation