### PR TITLE
Feature: Duplicate Improvements

### DIFF
--- a/spa_sequencer/shot/core.py
+++ b/spa_sequencer/shot/core.py
@@ -244,7 +244,7 @@ def duplicate_scene(
     scene: bpy.types.Scene,
     name: str,
     manifest: DuplicationManifest = None,
-) -> bpy.types.Scene:
+) -> tuple[bpy.types.Scene, DuplicationManifest]:
     """Duplicates `scene` as a new scene named `name`.
 
     :param context: The context

--- a/spa_sequencer/shot/core.py
+++ b/spa_sequencer/shot/core.py
@@ -320,7 +320,7 @@ def duplicate_scene(
     for region3D, view_mode in region3D_view_mode.items():
         region3D.view_perspective = view_mode
 
-    return new_scene
+    return new_scene, manifest
 
 
 def rename_all_datablocks_from_collection(
@@ -784,4 +784,3 @@ def register():
 def unregister():
     del bpy.types.Strip.audition
     unregister_classes(classes)
-

--- a/spa_sequencer/shot/ops.py
+++ b/spa_sequencer/shot/ops.py
@@ -15,7 +15,7 @@ from .core import (
     new_audition_strip,
     get_audition_strip,
     set_active_audition,
-    get_strip_container
+    get_strip_container,
 )
 from .naming import shot_naming, ShotNamingProperty
 from ..sync.core import (
@@ -23,6 +23,7 @@ from ..sync.core import (
     get_sync_settings,
     remap_frame_value,
 )
+from ..sequence.action_copy import action_copy_scene
 from ..utils import get_edit_scene, register_classes, unregister_classes
 
 
@@ -319,46 +320,119 @@ class SEQUENCER_OT_shot_duplicate(bpy.types.Operator):
     bl_description = "Duplicate selected shot(s) and append them to the timeline"
     bl_options = {"UNDO"}
 
-    duplicate_scene: bpy.props.BoolProperty(
-        name="Duplicate Scene",
-        description="Whether to also duplicate the underlying Scene",
-        default=False,
-        options={"SKIP_SAVE"},
+    scene_mode: bpy.props.EnumProperty(  # type: ignore
+        name="Scene Mode",
+        description="If/how to duplicate the underlying Scene",
+        items=(
+            (
+                "FULL_COPY",  # TODO debug when running this twice in a row no duplicate is made?
+                "Full Copy",
+                "Create a duplicate of the current Scene and all referenced datablocks.",
+            ),
+            (
+                "LINK_COPY",
+                "Linked Copy",
+                "Create a duplicate of the current Scene sharing the datablocks of the current Scene.",
+            ),
+            (
+                "ACTION_COPY",
+                "Action Copy",
+                "Created linked duplicates of animated objects (sharing mesh data), and keep links to all static objects/collections.",
+            ),
+            (
+                "KEEP_SCENE",
+                "Keep Current Timing",
+                "Place the duplicated shot on a new channel with the active strip's timing",
+            ),
+        ),
+        default="KEEP_SCENE",
+    )
+
+    timing_mode: bpy.props.EnumProperty(  # type: ignore
+        name="Timing Mode",
+        description="How the timing (inner scene & sequence timeline) is determined",
+        items=(
+            (
+                "APPEND_TIME",
+                "Append to Timeline",
+                "Place the duplicated shot after the last strip on the timeline",
+            ),
+            (
+                "KEEP_TIME",
+                "Keep Current Timing",
+                "Place the duplicated shot on a new channel with the active strip's timing",
+            ),
+        ),
+        default="KEEP_TIME",
     )
 
     @classmethod
     def poll(cls, context: bpy.types.Context):
         return bool(context.selected_strips)
 
-    @staticmethod
+    def invoke(self, context: bpy.types.Context, event):
+        return context.window_manager.invoke_props_dialog(self)
+
+    def draw(self, layout):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.prop(self, "scene_mode")
+        layout.prop(self, "timing_mode")
+
+    def get_next_free_channel(
+        self,
+        strip_container: bpy.types.SequenceEditor | bpy.types.MetaStrip,
+        strip: bpy.types.Strip,
+    ) -> int:
+        """Find the next channel up that accommodates the strips range."""
+
+        occupied = {
+            s.channel for s in strip_container.strips
+            if s.left_handle < strip.right_handle and s.right_handle > strip.left_handle
+        }
+        return next(c for c in range(strip.channel + 1, 128) if c not in occupied)
+
     def duplicate_shot(
-        context: bpy.types.Context,
-        strip: bpy.types.SceneStrip,
-        name: str,
-        duplicate_scene: bool,
+        self, context: bpy.types.Context, strip: bpy.types.SceneStrip, name: str
     ) -> bpy.types.SceneStrip:
-        strip_container = get_strip_container(strip.id_data.sequence_editor)
-        if duplicate_scene:
-            shot_scene = duplicate_scene(context, strip.scene, name)
-        else:
+        strips = get_strip_container(strip.id_data.sequence_editor)
+
+        # Get the Scene
+        if self.scene_mode == "ACTION_COPY":
+            shot_scene, manifest = action_copy_scene(context, strip.scene, name)
+        elif self.scene_mode == "FULL_COPY":
+            shot_scene, manifest = duplicate_scene(context, strip.scene, name)
+        elif self.scene_mode == "LINK_COPY":
+            with context.temp_override(scene=strip.scene):
+                bpy.ops.scene.new(type="LINK_COPY")
+            shot_scene = context.scene
+            shot_scene.name = name
+        else:  # KEEP_SCENE
             shot_scene = strip.scene
 
-        # Find the frame where to insert the duplicated strip
-        insert_frame = get_last_sequence(strip_container.strips).right_handle
+        # Placement in Sequencer Timeline
+        if self.timing_mode == "APPEND_TIME":
+            insert_frame = get_last_sequence(strips.strips).right_handle
+            new_channel = strip.channel
+        else:  # KEEP
+            insert_frame = strip.left_handle
+            new_channel = self.get_next_free_channel(strips, strip)
 
-        # Create new strip
-        new_strip = strip_container.strips.new_scene(
-            name, shot_scene, strip.channel, insert_frame
-        )
-
+        new_strip = strips.strips.new_scene(name, shot_scene, new_channel, insert_frame)
         new_strip.duration = strip.duration
 
-        if not duplicate_scene:
+        if self.scene_mode in {"FULL_COPY", "ACTION_COPY"}:
+            new_strip.scene_camera = manifest.get(strip.scene_camera)
+        else:  # LINK_COPY, KEEP_SCENE
             new_strip.scene_camera = strip.scene_camera
-            handle_offset = get_last_used_frame(strip_container.strips, shot_scene)
-            slip_shot_content(new_strip, handle_offset)
-        else:
-            new_strip.scene_camera = strip.scene.camera
+
+        # Adjust inner Scene Timing
+        if self.timing_mode == "APPEND_TIME":
+            strip_offset = get_last_used_frame(strips.strips, shot_scene)
+        else:  # Keep
+            strip_offset = strip.left_handle_offset
+
+        slip_shot_content(new_strip, strip_offset)
 
         return new_strip
 
@@ -370,7 +444,7 @@ class SEQUENCER_OT_shot_duplicate(bpy.types.Operator):
         new_strips = []
         for strip in get_selected_scene_sequences(strip_container.strips):
             name = shot_naming.next_shot_name_from_sequences(strip_container)
-            new_strip = self.duplicate_shot(context, strip, name, self.duplicate_scene)
+            new_strip = self.duplicate_shot(context, strip, name)
             new_strips.append(new_strip)
 
         if not new_strips:
@@ -386,7 +460,7 @@ class SEQUENCER_OT_shot_duplicate(bpy.types.Operator):
         sed.active_strip = new_strips[0]
         for strip in new_strips:
             strip.select = True
-            
+
         edit_scene = get_edit_scene(context)
 
         edit_scene.frame_end = max(

--- a/spa_sequencer/shot/ops.py
+++ b/spa_sequencer/shot/ops.py
@@ -23,7 +23,7 @@ from ..sync.core import (
     get_sync_settings,
     remap_frame_value,
 )
-from ..sequence.action_copy import action_copy_scene
+from ..action_copy.core import action_copy_scene
 from ..utils import get_edit_scene, register_classes, unregister_classes
 
 

--- a/spa_sequencer/shot/ops.py
+++ b/spa_sequencer/shot/ops.py
@@ -341,8 +341,8 @@ class SEQUENCER_OT_shot_duplicate(bpy.types.Operator):
             ),
             (
                 "KEEP_SCENE",
-                "Keep Current Timing",
-                "Place the duplicated shot on a new channel with the active strip's timing",
+                "Keep Current Scene",
+                "Use the active Scene Strip's target scene as the target of the duplicated strip",
             ),
         ),
         default="KEEP_SCENE",

--- a/tests/test_shot.py
+++ b/tests/test_shot.py
@@ -30,7 +30,7 @@ def test_scene_duplication_same_name():
 def test_scene_duplication():
     ref_scene = bpy.context.scene
     # Create a new scene named "SceneCopy"
-    new_scene = duplicate_scene(bpy.context, ref_scene, "SceneCopy")
+    new_scene, _ = duplicate_scene(bpy.context, ref_scene, "SceneCopy")
 
     # Check collection duplication
     assert len(new_scene.collection.children) == len(ref_scene.collection.children)
@@ -46,7 +46,7 @@ def test_scene_duplication():
     )
     new_scene.collection.objects.link(new_obj)
     # Create another scene from "SceneCopy"
-    new_scene2 = duplicate_scene(bpy.context, new_scene, "SceneCopy2")
+    new_scene2, _ = duplicate_scene(bpy.context, new_scene, "SceneCopy2")
     # Check that this last scene has been created from "SceneCopy"
     assert len(new_scene2.objects) == len(new_scene.objects) != len(ref_scene.objects)
     # Check datablack auto-renaming
@@ -61,7 +61,7 @@ def test_scene_duplication_animation_data():
     ref_obj.keyframe_insert(data_path="location", frame=1)
 
     # Duplicate the scene
-    new_scene = duplicate_scene(bpy.context, ref_scene, "SceneCopy")
+    new_scene, _ = duplicate_scene(bpy.context, ref_scene, "SceneCopy")
 
     # Ensure new scene's active object has animation data
     new_obj = new_scene.view_layers[0].objects.active
@@ -231,7 +231,7 @@ def test_scene_rename_invalid_name():
 def test_scene_delete_scene_duplicate():
     # Duplicate the default scene
     manifest = DuplicationManifest()
-    sceneA = duplicate_scene(bpy.context, bpy.context.scene, "SceneA", manifest)
+    sceneA, _ = duplicate_scene(bpy.context, bpy.context.scene, "SceneA", manifest)
 
     # Delete this new scene
     del_count = delete_scene(sceneA, True)
@@ -248,7 +248,7 @@ def test_scene_delete_scene_duplicate():
 def test_scene_delete_scene_duplicate_with_shared_collection():
     # Duplicate default scene
     manifest = DuplicationManifest()
-    sceneA = duplicate_scene(bpy.context, bpy.context.scene, "SceneA", manifest)
+    sceneA, _ = duplicate_scene(bpy.context, bpy.context.scene, "SceneA", manifest)
     # Link a collection from the default scene into the new scene
     shared_col = bpy.context.scene.collection.children[0]
     sceneA.collection.children.link(shared_col)


### PR DESCRIPTION
Closes: https://github.com/NickTiny/SPArk-sequencer-addon/issues/58

MERGE AFTER: https://github.com/NickTiny/SPArk-sequencer-addon/pull/75


## Changes
Improves duplicate operator to add more customization when duplicating the Scene.

New options:



**Scene Mode**
- Keep Current Scene (current behavior)
- Action Copy #75 
- Linked Copy
- Full Copy

**Timing Mode**
- Append to Timeline (current behavior)
- Keep current Timeline


<img width="555" height="254" alt="image" src="https://github.com/user-attachments/assets/482c4f2f-0788-4851-b281-0fc2c7417257" />
<img width="555" height="254" alt="image" src="https://github.com/user-attachments/assets/eb380c97-eeb1-43c4-a424-5c941a672ba3" />
