### PR TITLE
Fix: Remove Versioning Code & Clean-Up

### DIFF
--- a/spa_sequencer/editorial/vse_io/ops.py
+++ b/spa_sequencer/editorial/vse_io/ops.py
@@ -86,11 +86,7 @@ class IMPORT_OT_otio(bpy.types.Operator, ImportHelper):
             "channel": channel,
             "frame_start": frame_start,
         }
-        if bpy.app.version >= (5, 0, 0):
-            kwargs["length"] = duration
-        else:
-            # Older Blender versions expect `frame_end` instead of `length`.
-            kwargs["frame_end"] = frame_start + duration
+        kwargs["length"] = duration
 
         new_strip = self.seq_editor.strips.new_effect(**kwargs)
         # Indicate missing media reference.

--- a/spa_sequencer/render/props.py
+++ b/spa_sequencer/render/props.py
@@ -8,11 +8,7 @@ import bpy
 from ..utils import register_classes, unregister_classes
 
 
-BLENDER_EEVEE = (
-    "BLENDER_EEVEE_NEXT"
-    if (4, 2, 0) < bpy.app.version < (5, 0, 0)
-    else "BLENDER_EEVEE"
-)
+BLENDER_EEVEE = "BLENDER_EEVEE"
 
 MEDIA_TYPES_FORMATS = {
     "IMAGES": ("JPEG", "jpg"),

--- a/spa_sequencer/render/tasks.py
+++ b/spa_sequencer/render/tasks.py
@@ -220,8 +220,7 @@ class StripRenderTask(BaseRenderTask):
             # Filepath: add separator between resolved name and auto frame number suffix
             filepath += "."
             # Setup render settings
-            if bpy.app.version >= (5, 0, 0):
-                self.overrides.set(render.image_settings, "media_type", "IMAGE")
+            self.overrides.set(render.image_settings, "media_type", "IMAGE")
             self.overrides.set(render.image_settings, "file_format", file_format)
             self.overrides.set(render.image_settings, "quality", 100)
             self.overrides.set(render.image_settings, "color_mode", "RGB")
@@ -229,8 +228,7 @@ class StripRenderTask(BaseRenderTask):
             # Filepath: add extension to avoid auto frame range suffix
             filepath += f".{file_ext}"
             # Setup render settings
-            if bpy.app.version >= (5, 0, 0):
-                self.overrides.set(render.image_settings, "media_type", "VIDEO")
+            self.overrides.set(render.image_settings, "media_type", "VIDEO")
             self.overrides.set(render.image_settings, "file_format", "FFMPEG")
             self.overrides.set(render.ffmpeg, "format", file_format)
             self.overrides.set(render.ffmpeg, "constant_rate_factor", "PERC_LOSSLESS")
@@ -288,7 +286,7 @@ class StripRenderTask(BaseRenderTask):
                 self.output_channel_offset,
                 render_options,
             )
-            
+
     def create_image_media_strip(self, sed: bpy.types.SequenceEditor, scene_strip: bpy.types.SceneStrip, channel_offset: int):
         # Create a image strip that only contains first frame
         frame_number = scene_strip.scene.frame_start 
@@ -299,16 +297,16 @@ class StripRenderTask(BaseRenderTask):
             channel=scene_strip.channel + channel_offset,
             frame_start=scene_strip.left_handle,
         )
-               
+
         if scene_strip.duration <= 1:
             return strip
-               
+
         # First frame already include start from second frame
         for idx in range(1, scene_strip.duration):
             frame_number = scene_strip.scene.frame_start + idx 
             img_path = scene_strip.scene.render.frame_path(frame=frame_number)
             strip.elements.append(os.path.basename(bpy.path.abspath(img_path)))
-            
+
         return strip
 
     def create_output_media_strip(

--- a/spa_sequencer/shot/core.py
+++ b/spa_sequencer/shot/core.py
@@ -5,7 +5,6 @@ from typing import Callable, List
 
 import bpy
 
-from ..utils import is_grease_pencil_instance
 from ..preferences import get_addon_prefs
 from ..sync.core import (
     get_sync_settings,
@@ -214,7 +213,7 @@ def remap_relations(manifest: DuplicationManifest):
     def _remap_modifiers(new_object: bpy.types.Object):
         """Remap `new_object`'s modifiers properties."""
         _remap_pointer_properties(new_object.modifiers)
-        if is_grease_pencil_instance(new_object.data):
+        if isinstance(new_object.data, bpy.types.GreasePencil):
             _remap_pointer_properties(new_object.modifiers)
             _remap_pointer_properties(new_object.shader_effects)
 
@@ -784,4 +783,3 @@ def register():
 def unregister():
     del bpy.types.Strip.audition
     unregister_classes(classes)
-

--- a/spa_sequencer/sync/core.py
+++ b/spa_sequencer/sync/core.py
@@ -438,17 +438,16 @@ def sync_system_update(context: bpy.types.Context, force: bool = False):
         or not master_scene.sequence_editor
     ):
         return
-    
+
     # Disable sync_scene_time in active workspaces.
-    if bpy.app.version >= (5, 0, 0):
-        for window in context.window_manager.windows:
-            window.workspace.use_scene_time_sync = False
+    for window in context.window_manager.windows:
+        window.workspace.use_scene_time_sync = False
 
     # In order to evaluate if the master scene's current frame has changed,
     # we current have to rely on a system that stores the last frame values
     # that triggered a change.
     # This is a temporary solution that will be replaced when the
-    # frame_change_post callback recieve the correct Scene.
+    # frame_change_post callback receive the correct Scene.
     master_time_changed = sync_settings.last_master_frame != master_scene.frame_current
     scene_time_changed = sync_settings.last_strip_scene_frame != win_scene.frame_current
 

--- a/spa_sequencer/sync/core.py
+++ b/spa_sequencer/sync/core.py
@@ -7,7 +7,6 @@ import ctypes
 
 import bpy
 
-from ..utils import is_grease_pencil_instance
 from ..utils import register_classes, unregister_classes
 
 
@@ -267,7 +266,7 @@ def scene_change_manager(context: bpy.types.Context):
             if key == "brush":
                 set_grease_pencil_brush(context, value)
                 continue
-                
+
             if getattr(obj, key, None) != value:
                 setattr(obj, key, value)
 
@@ -288,7 +287,9 @@ def scene_change_manager(context: bpy.types.Context):
         # Store the active GP material and mode if any
         gp_material = None
 
-        if context.active_object and is_grease_pencil_instance(context.active_object.data):
+        if context.active_object and isinstance(
+            context.active_object.data, bpy.types.GreasePencil
+        ):
             gp_material = context.active_object.active_material
             sync_settings.last_gp_mode = context.active_object.mode
 
@@ -305,7 +306,9 @@ def scene_change_manager(context: bpy.types.Context):
 
         # If the new active object is a GP, restore the previously stored material
         # as active if also assigned.
-        if (gpencil := context.active_object) and is_grease_pencil_instance(gpencil.data):
+        if (gpencil := context.active_object) and isinstance(
+            gpencil.data, bpy.types.GreasePencil
+        ):
             if gp_material:
                 material_idx = gpencil.data.materials.find(gp_material.name)
                 if material_idx >= 0:

--- a/spa_sequencer/utils.py
+++ b/spa_sequencer/utils.py
@@ -115,15 +115,3 @@ def get_edit_scene(context: bpy.types.Context) -> bpy.types.Scene:
         return context.sequencer_scene
     else:
         return context.scene
-
-def is_grease_pencil_instance(data: bpy.types.ID) -> bool:
-    """Check if data block is a Grease Pencil instance, compatible with new 5.0 API and legacy.
-    https://developer.blender.org/docs/release_notes/5.0/python_api/#annotations-grease-pencil
-
-    Args:
-        data (bpy.types.ID): Data block to check.
-
-    Returns:
-        bool: True if data is a Grease Pencil instance, False otherwise.
-    """
-    return isinstance(data, bpy.types.GreasePencil)

--- a/spa_sequencer/utils.py
+++ b/spa_sequencer/utils.py
@@ -111,11 +111,11 @@ def get_edit_scene(context: bpy.types.Context) -> bpy.types.Scene:
     Returns:
         bpy.types.Scene: The sequencer scene.
     """
-    if bpy.app.version >= (5, 0, 0) and context.sequencer_scene is not None:
+    if context.sequencer_scene:
         return context.sequencer_scene
     else:
         return context.scene
-    
+
 def is_grease_pencil_instance(data: bpy.types.ID) -> bool:
     """Check if data block is a Grease Pencil instance, compatible with new 5.0 API and legacy.
     https://developer.blender.org/docs/release_notes/5.0/python_api/#annotations-grease-pencil
@@ -126,5 +126,4 @@ def is_grease_pencil_instance(data: bpy.types.ID) -> bool:
     Returns:
         bool: True if data is a Grease Pencil instance, False otherwise.
     """
-    gp_data_type = bpy.types.GreasePencil if bpy.app.version >= (5, 0, 0) else bpy.types.GreasePencilv3
-    return isinstance(data, gp_data_type)
+    return isinstance(data, bpy.types.GreasePencil)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -366,23 +366,23 @@ def test_sync_meta_strip(basic_synced_setup):
 def test_strip_jump_next(basic_synced_setup):
     """Ensure the custom `sequence.strip_jump_viewport` operator moves master frame to next strip."""    
     edit_scene, shot_strip_1 = basic_synced_setup
-    
-    shot_strip_2 = create_shot_scene(edit_scene, 1, shot_strip_1.frame_final_end)
+
+    shot_strip_2 = create_shot_scene(edit_scene, 1, shot_strip_1.right_handle)
 
     # Start from the first shot
-    edit_scene.frame_set(shot_strip_1.frame_final_start)
+    edit_scene.frame_set(shot_strip_1.left_handle)
 
     # Invoke our operator to jump to the next strip (using offset)
     bpy.ops.sequence.strip_jump_viewport(next=True)
 
     # Master scene should now be at the second shot's start
-    assert edit_scene.frame_current == shot_strip_2.frame_final_start
+    assert edit_scene.frame_current == shot_strip_2.left_handle
 
 def test_strip_jump_previous(basic_synced_setup):
     """Ensure the custom `sequence.strip_jump_viewport` operator moves master frame to previous strip."""
     edit_scene, shot_strip_1 = basic_synced_setup
-    
-    shot_strip_2 = create_shot_scene(edit_scene, 1, shot_strip_1.frame_final_start)
-    
-    edit_scene.frame_set(shot_strip_2.frame_final_start)
+
+    shot_strip_2 = create_shot_scene(edit_scene, 1, shot_strip_1.left_handle)
+
+    edit_scene.frame_set(shot_strip_2.left_handle)
     assert edit_scene.sequence_editor.active_strip == shot_strip_2


### PR DESCRIPTION
Closes: #73 

## Changes

 - Remove Checks for Blender 5.0 
- Clean-Up 5.1 API in tests related: 61f87d9c8a7121d784851f987c7af62ffc1d4c9e
- Remove `is_grease_pencil_instance` helper 