### PR TITLE
Fix: Add Support for Legacy Installs

### DIFF
--- a/spa_sequencer/__init__.py
+++ b/spa_sequencer/__init__.py
@@ -13,6 +13,18 @@ from . import (
 )
 
 
+bl_info = {
+    "name": "SPArk Sequencer",
+    "author": "Nick Alberelli & The SPA Studios",
+    "description": "Toolset to improve the sequence workflow in Blender.",
+    "blender": (5, 1, 0),
+    "version": (0, 1, 5),
+    "location": "",
+    "warning": "",
+    "category": "SPA",
+}
+
+
 packages = (
     sync,
     shot,


### PR DESCRIPTION
## Changes

Some studios use scripts that only rely on the legacy add-on install system instead of the more modern extensions platform.

It is no big deal to restore this bl_info here although these installs will not support wheels once we return the OTIO wheels to the release.